### PR TITLE
feat: add AI-powered roadmap slicer

### DIFF
--- a/scripts/night-watch-slicer-cron.sh
+++ b/scripts/night-watch-slicer-cron.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Night Watch Slicer Cron Runner (project-agnostic)
+# Usage: night-watch-slicer-cron.sh /path/to/project
+#
+# This is a thin wrapper that acquires a lock and calls `night-watch slice`.
+# The CLI command handles all the logic directly in TypeScript.
+#
+# NOTE: This script expects environment variables to be set by the caller.
+# The Node.js CLI will inject config values via environment variables.
+# Required env vars (with defaults shown):
+#   NW_SLICER_MAX_RUNTIME=600  - Maximum runtime in seconds (10 minutes)
+#   NW_PROVIDER_CMD=claude     - AI provider CLI to use (claude, codex, etc.)
+#   NW_DRY_RUN=0               - Set to 1 for dry-run mode (prints diagnostics only)
+
+PROJECT_DIR="${1:?Usage: $0 /path/to/project}"
+PROJECT_NAME=$(basename "${PROJECT_DIR}")
+LOG_DIR="${PROJECT_DIR}/logs"
+LOG_FILE="${LOG_DIR}/night-watch-slicer.log"
+LOCK_FILE=""
+MAX_RUNTIME="${NW_SLICER_MAX_RUNTIME:-600}"  # 10 minutes
+MAX_LOG_SIZE="524288"  # 512 KB
+PROVIDER_CMD="${NW_PROVIDER_CMD:-claude}"
+
+# Ensure NVM / Node / Night Watch CLI are on PATH
+export NVM_DIR="${HOME}/.nvm"
+[ -s "${NVM_DIR}/nvm.sh" ] && . "${NVM_DIR}/nvm.sh"
+
+mkdir -p "${LOG_DIR}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=night-watch-helpers.sh
+source "${SCRIPT_DIR}/night-watch-helpers.sh"
+PROJECT_RUNTIME_KEY=$(project_runtime_key "${PROJECT_DIR}")
+LOCK_FILE="/tmp/night-watch-slicer-${PROJECT_RUNTIME_KEY}.lock"
+
+# Validate provider
+if ! validate_provider "${PROVIDER_CMD}"; then
+  echo "ERROR: Unknown provider: ${PROVIDER_CMD}" >&2
+  exit 1
+fi
+
+rotate_log
+
+if ! acquire_lock "${LOCK_FILE}"; then
+  exit 0
+fi
+
+cleanup_on_exit() {
+  rm -f "${LOCK_FILE}"
+}
+
+trap cleanup_on_exit EXIT
+
+log "START: Running roadmap slicer for ${PROJECT_DIR}"
+
+# Dry-run mode: print diagnostics and exit
+if [ "${NW_DRY_RUN:-0}" = "1" ]; then
+  echo "=== Dry Run: Roadmap Slicer ==="
+  echo "Provider: ${PROVIDER_CMD}"
+  echo "Project Dir: ${PROJECT_DIR}"
+  echo "Timeout: ${MAX_RUNTIME}s"
+  exit 0
+fi
+
+# Resolve night-watch CLI
+CLI_BIN=""
+if ! CLI_BIN=$(resolve_night_watch_cli); then
+  log "ERROR: Could not resolve night-watch CLI"
+  exit 1
+fi
+
+# Run the slice command with timeout
+EXIT_CODE=0
+if timeout "${MAX_RUNTIME}" "${CLI_BIN}" slice >> "${LOG_FILE}" 2>&1; then
+  EXIT_CODE=0
+else
+  EXIT_CODE=$?
+fi
+
+if [ ${EXIT_CODE} -eq 0 ]; then
+  log "DONE: Slicer completed successfully"
+elif [ ${EXIT_CODE} -eq 124 ]; then
+  log "TIMEOUT: Slicer killed after ${MAX_RUNTIME}s"
+else
+  log "FAIL: Slicer exited with code ${EXIT_CODE}"
+fi
+
+exit ${EXIT_CODE}

--- a/src/__tests__/commands/slice.test.ts
+++ b/src/__tests__/commands/slice.test.ts
@@ -1,0 +1,271 @@
+/**
+ * Tests for the slice command
+ *
+ * These tests focus on testing the exported helper functions directly,
+ * which is more reliable than mocking the entire module system.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { Command } from "commander";
+
+// Mock console methods before importing
+const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+const mockConsoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+// Mock process.exit
+const mockExit = vi.spyOn(process, "exit").mockImplementation((code) => {
+  throw new Error(`process.exit(${code})`);
+});
+
+// Mock process.cwd
+const mockCwd = vi.spyOn(process, "cwd");
+
+// Import after setting up mocks
+import {
+  buildEnvVars,
+  applyCliOverrides,
+  ISliceOptions,
+} from "../../commands/slice.js";
+import { INightWatchConfig, IRoadmapScannerConfig } from "../../types.js";
+
+// Helper to create a valid config with roadmap scanner settings
+function createTestConfig(overrides: Partial<INightWatchConfig> = {}): INightWatchConfig {
+  const defaultRoadmapScanner: IRoadmapScannerConfig = {
+    enabled: true,
+    roadmapPath: "ROADMAP.md",
+    autoScanInterval: 300,
+    slicerSchedule: "0 */6 * * *",
+    slicerMaxRuntime: 600,
+  };
+
+  return {
+    prdDir: "docs/PRDs/night-watch",
+    maxRuntime: 7200,
+    reviewerMaxRuntime: 3600,
+    branchPrefix: "night-watch",
+    branchPatterns: ["feat/", "night-watch/"],
+    minReviewScore: 80,
+    maxLogSize: 524288,
+    cronSchedule: "0 0-21 * * *",
+    reviewerSchedule: "0 0,3,6,9,12,15,18,21 * * *",
+    cronScheduleOffset: 0,
+    provider: "claude",
+    reviewerEnabled: true,
+    maxRetries: 3,
+    prdPriority: [],
+    providerEnv: {},
+    notifications: { webhooks: [] },
+    roadmapScanner: defaultRoadmapScanner,
+    defaultBranch: "",
+    ...overrides,
+  };
+}
+
+describe("slice command", () => {
+  let tempDir: string;
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "night-watch-test-"));
+    mockCwd.mockReturnValue(tempDir);
+
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Clear NW_* environment variables
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("NW_")) {
+        delete process.env[key];
+      }
+    }
+
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+
+    // Restore original environment
+    for (const key of Object.keys(process.env)) {
+      if (key.startsWith("NW_")) {
+        delete process.env[key];
+      }
+    }
+    for (const [key, value] of Object.entries(originalEnv)) {
+      if (key.startsWith("NW_")) {
+        process.env[key] = value;
+      }
+    }
+
+    vi.clearAllMocks();
+  });
+
+  describe("buildEnvVars", () => {
+    it("should build correct env vars", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_PROVIDER_CMD).toBe("claude");
+      expect(env.NW_SLICER_MAX_RUNTIME).toBe("600");
+      expect(env.NW_PRD_DIR).toBe("docs/PRDs/night-watch");
+      expect(env.NW_ROADMAP_PATH).toBe("ROADMAP.md");
+    });
+
+    it("should include slicer max runtime in env", () => {
+      const config = createTestConfig({
+        roadmapScanner: {
+          enabled: true,
+          roadmapPath: "ROADMAP.md",
+          autoScanInterval: 300,
+          slicerSchedule: "0 */6 * * *",
+          slicerMaxRuntime: 600,
+        },
+      });
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_SLICER_MAX_RUNTIME).toBe("600");
+    });
+
+    it("should set NW_PROVIDER_CMD for codex provider", () => {
+      const config = createTestConfig({ provider: "codex" });
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_PROVIDER_CMD).toBe("codex");
+    });
+
+    it("should set NW_DRY_RUN when dryRun is true", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: true };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_DRY_RUN).toBe("1");
+    });
+
+    it("should not set NW_DRY_RUN when dryRun is false", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_DRY_RUN).toBeUndefined();
+    });
+
+    it("should include NW_EXECUTION_CONTEXT=agent", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_EXECUTION_CONTEXT).toBe("agent");
+    });
+
+    it("should include providerEnv variables", () => {
+      const config = createTestConfig({
+        providerEnv: {
+          ANTHROPIC_API_KEY: "test-key-123",
+        },
+      });
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.ANTHROPIC_API_KEY).toBe("test-key-123");
+    });
+
+    it("should set custom slicer max runtime", () => {
+      const config = createTestConfig({
+        roadmapScanner: {
+          enabled: true,
+          roadmapPath: "ROADMAP.md",
+          autoScanInterval: 300,
+          slicerSchedule: "0 */6 * * *",
+          slicerMaxRuntime: 1800, // 30 minutes
+        },
+      });
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_SLICER_MAX_RUNTIME).toBe("1800");
+    });
+
+    it("should set custom roadmap path", () => {
+      const config = createTestConfig({
+        roadmapScanner: {
+          enabled: true,
+          roadmapPath: "docs/ROADMAP.md",
+          autoScanInterval: 300,
+          slicerSchedule: "0 */6 * * *",
+          slicerMaxRuntime: 600,
+        },
+      });
+      const options: ISliceOptions = { dryRun: false };
+
+      const env = buildEnvVars(config, options);
+
+      expect(env.NW_ROADMAP_PATH).toBe("docs/ROADMAP.md");
+    });
+  });
+
+  describe("applyCliOverrides", () => {
+    it("should override timeout with --timeout flag", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false, timeout: "1200" };
+
+      const overridden = applyCliOverrides(config, options);
+
+      expect(overridden.roadmapScanner.slicerMaxRuntime).toBe(1200);
+    });
+
+    it("should override provider with --provider flag", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false, provider: "codex" };
+
+      const overridden = applyCliOverrides(config, options);
+
+      expect(overridden.provider).toBe("codex");
+    });
+
+    it("should not modify config when no overrides provided", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false };
+
+      const overridden = applyCliOverrides(config, options);
+
+      expect(overridden.roadmapScanner.slicerMaxRuntime).toBe(600);
+      expect(overridden.provider).toBe("claude");
+    });
+
+    it("should handle invalid timeout gracefully", () => {
+      const config = createTestConfig();
+      const options: ISliceOptions = { dryRun: false, timeout: "invalid" };
+
+      const overridden = applyCliOverrides(config, options);
+
+      // Should not override when parsing fails
+      expect(overridden.roadmapScanner.slicerMaxRuntime).toBe(600);
+    });
+  });
+
+  describe("command registration", () => {
+    it("should register slice command", async () => {
+      // Import the command registration function
+      const { sliceCommand } = await import("../../commands/slice.js");
+
+      const program = new Command();
+      sliceCommand(program);
+
+      expect(program.commands.map((c) => c.name())).toContain("slice");
+    });
+  });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -543,4 +543,49 @@ describe("config", () => {
       expect(config.notifications.webhooks[0].events).toEqual(["run_timeout"]);
     });
   });
+
+  describe("slicer config", () => {
+    it("should load slicerSchedule from config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          roadmapScanner: {
+            enabled: true,
+            slicerSchedule: "0 */4 * * *",
+          },
+        })
+      );
+
+      const config = loadConfig(tempDir);
+
+      expect(config.roadmapScanner.slicerSchedule).toBe("0 */4 * * *");
+    });
+
+    it("should use default slicerMaxRuntime", () => {
+      const config = loadConfig(tempDir);
+
+      expect(config.roadmapScanner.slicerMaxRuntime).toBe(600);
+    });
+
+    it("should override slicerSchedule from env", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          roadmapScanner: {
+            enabled: true,
+            slicerSchedule: "0 */4 * * *",
+          },
+        })
+      );
+
+      const envValue = "0 */2 * * *";
+      process.env.NW_SLICER_SCHEDULE = envValue;
+
+      const config = loadConfig(tempDir);
+
+      expect(config.roadmapScanner.slicerSchedule).toBe(envValue);
+    });
+  });
 });

--- a/src/__tests__/roadmap-scanner.test.ts
+++ b/src/__tests__/roadmap-scanner.test.ts
@@ -2,13 +2,27 @@
  * Tests for Roadmap Scanner
  */
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
-import { getRoadmapStatus, scanRoadmap } from "../utils/roadmap-scanner.js";
+import * as childProcess from "child_process";
+import * as crypto from "crypto";
+import { getRoadmapStatus, scanRoadmap, sliceNextItem, sliceRoadmapItem } from "../utils/roadmap-scanner.js";
 import { INightWatchConfig } from "../types.js";
 import { loadRoadmapState, getStateFilePath } from "../utils/roadmap-state.js";
+import { IRoadmapItem } from "../utils/roadmap-parser.js";
+
+// Helper to compute hash the same way as generateItemHash
+function computeHash(title: string): string {
+  const normalizedTitle = title.toLowerCase().trim();
+  return crypto.createHash("sha256").update(normalizedTitle).digest("hex").slice(0, 8);
+}
+
+// Mock child_process.spawn
+vi.mock("child_process", () => ({
+  spawn: vi.fn(),
+}));
 
 describe("roadmap-scanner", () => {
   let tempDir: string;
@@ -35,6 +49,8 @@ describe("roadmap-scanner", () => {
       enabled: true,
       roadmapPath: "ROADMAP.md",
       autoScanInterval: 300,
+      slicerSchedule: "0 * * * *",
+      slicerMaxRuntime: 3600,
     },
   };
 
@@ -46,7 +62,76 @@ describe("roadmap-scanner", () => {
     },
   };
 
+  // Helper to create a mock provider process that succeeds
+  function mockProviderSuccess(filename: string) {
+    const mockChild = {
+      stdout: {
+        on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+          if (event === "data") {
+            cb(Buffer.from("Mock provider output\n"));
+          }
+        }),
+      },
+      stderr: {
+        on: vi.fn((event: string, _cb: (data: Buffer) => void) => {}),
+      },
+      on: vi.fn((event: string, cb: (code: number | null) => void) => {
+        if (event === "close") {
+          // Create the expected file when provider "succeeds"
+          const filePath = path.join(prdDir, filename);
+          fs.writeFileSync(filePath, "# Mock PRD Content\n", "utf-8");
+          cb(0);
+        }
+      }),
+    };
+    (childProcess.spawn as ReturnType<typeof vi.fn>).mockReturnValue(mockChild);
+    return mockChild;
+  }
+
+  // Helper to create a mock provider process that fails
+  function mockProviderFailure() {
+    const mockChild = {
+      stdout: {
+        on: vi.fn(),
+      },
+      stderr: {
+        on: vi.fn((event: string, cb: (data: Buffer) => void) => {
+          if (event === "data") {
+            cb(Buffer.from("Mock error\n"));
+          }
+        }),
+      },
+      on: vi.fn((event: string, cb: (code: number | null) => void) => {
+        if (event === "close") {
+          cb(1);
+        }
+      }),
+    };
+    (childProcess.spawn as ReturnType<typeof vi.fn>).mockReturnValue(mockChild);
+    return mockChild;
+  }
+
+  // Helper to create a mock provider process that does not create a file
+  function mockProviderNoFile() {
+    const mockChild = {
+      stdout: {
+        on: vi.fn(),
+      },
+      stderr: {
+        on: vi.fn(),
+      },
+      on: vi.fn((event: string, cb: (code: number | null) => void) => {
+        if (event === "close") {
+          cb(0); // Exit success but no file created
+        }
+      }),
+    };
+    (childProcess.spawn as ReturnType<typeof vi.fn>).mockReturnValue(mockChild);
+    return mockChild;
+  }
+
   beforeEach(() => {
+    vi.clearAllMocks();
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "roadmap-scanner-test-"));
     prdDir = path.join(tempDir, "docs/PRDs/night-watch");
     roadmapPath = path.join(tempDir, "ROADMAP.md");
@@ -57,6 +142,7 @@ describe("roadmap-scanner", () => {
 
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
   });
 
   describe("getRoadmapStatus", () => {
@@ -88,14 +174,13 @@ describe("roadmap-scanner", () => {
       // Create ROADMAP.md
       fs.writeFileSync(roadmapPath, `## Features\n- [ ] Item 1\n`);
 
-      // Create state with processed item
+      // Create state with processed item - use correct hash
       const statePath = getStateFilePath(prdDir);
       const state = {
         version: 1,
         lastScan: "",
         items: {
-          acadda60: {
-            // hash for "item 1"
+          [computeHash("Item 1")]: {
             title: "Item 1",
             prdFile: "01-item-1.md",
             createdAt: new Date().toISOString(),
@@ -150,63 +235,32 @@ describe("roadmap-scanner", () => {
     });
   });
 
-  describe("scanRoadmap", () => {
-    it("should create PRD files from unprocessed items", () => {
+  describe("sliceNextItem", () => {
+    it("sliceNextItem should pick the first unprocessed item", async () => {
       fs.writeFileSync(
         roadmapPath,
         `## Features
-- [ ] New Feature
-  This is a description of the new feature.
+- [ ] Feature Alpha
+- [ ] Feature Beta
 `
       );
 
-      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
-
-      expect(result.created).toHaveLength(1);
-      expect(result.created[0]).toBe("01-new-feature.md");
-      expect(result.errors).toHaveLength(0);
-
-      // Verify file exists
-      const prdFile = path.join(prdDir, "01-new-feature.md");
-      expect(fs.existsSync(prdFile)).toBe(true);
-
-      // Verify content has roadmap context
-      const content = fs.readFileSync(prdFile, "utf-8");
-      expect(content).toContain("<!-- Roadmap Context:");
-      expect(content).toContain("Section: Features");
-      expect(content).toContain("Description: This is a description of the new feature.");
-      expect(content).toContain("# PRD: New Feature");
-    });
-
-    it("should skip already-processed items", () => {
-      fs.writeFileSync(roadmapPath, `## Features\n- [ ] Item 1\n`);
-
-      // Create state with processed item
-      const statePath = getStateFilePath(prdDir);
-      const state = {
-        version: 1,
-        lastScan: "",
-        items: {
-          acadda60: {
-            // hash for "item 1"
-            title: "Item 1",
-            prdFile: "01-item-1.md",
-            createdAt: new Date().toISOString(),
-          },
-        },
-      };
-      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+      // Mock provider to succeed
+      mockProviderSuccess("01-feature-alpha.md");
 
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const result = await sliceNextItem(tempDir, config);
 
-      expect(result.created).toHaveLength(0);
-      expect(result.skipped).toHaveLength(1);
-      expect(result.skipped[0]).toContain("processed");
+      expect(result.sliced).toBe(true);
+      expect(result.file).toBe("01-feature-alpha.md");
+      expect(result.item?.title).toBe("Feature Alpha");
+
+      // Verify state was updated
+      const state = loadRoadmapState(prdDir);
+      expect(Object.keys(state.items)).toHaveLength(1);
     });
 
-    it("should skip checked items", () => {
+    it("sliceNextItem should skip checked items", async () => {
       fs.writeFileSync(
         roadmapPath,
         `## Features
@@ -214,117 +268,215 @@ describe("roadmap-scanner", () => {
 `
       );
 
+      // No need to mock - spawn won't be called
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const result = await sliceNextItem(tempDir, config);
 
-      expect(result.created).toHaveLength(0);
-      expect(result.skipped).toHaveLength(1);
-      expect(result.skipped[0]).toContain("checked");
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("No pending items");
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
     });
 
-    it("should update state file after scan", () => {
-      fs.writeFileSync(roadmapPath, `## Features\n- [ ] New Feature\n`);
+    it("sliceNextItem should skip already-processed items", async () => {
+      fs.writeFileSync(roadmapPath, `## Features\n- [ ] Item One\n`);
 
+      // Create state with processed item - use correct hash
+      const statePath = getStateFilePath(prdDir);
+      const state = {
+        version: 1,
+        lastScan: "",
+        items: {
+          [computeHash("Item One")]: {
+            title: "Item One",
+            prdFile: "01-item-one.md",
+            createdAt: new Date().toISOString(),
+          },
+        },
+      };
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+      // No need to mock - spawn won't be called
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      scanRoadmap(tempDir, config);
+      const result = await sliceNextItem(tempDir, config);
 
-      // Verify state was updated
-      const state = loadRoadmapState(prdDir);
-      const hashes = Object.keys(state.items);
-
-      expect(hashes).toHaveLength(1);
-      expect(state.items[hashes[0]].title).toBe("New Feature");
-      expect(state.items[hashes[0]].prdFile).toBe("01-new-feature.md");
-      expect(state.lastScan).not.toBe("");
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("No pending items");
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
     });
 
-    it("should detect duplicates by existing PRD title match", () => {
-      fs.writeFileSync(roadmapPath, `## Features\n- [ ] Existing Feature\n`);
+    it("sliceNextItem should return no-pending when all done", async () => {
+      fs.writeFileSync(roadmapPath, `## Features\n- [ ] Done Feature\n`);
 
-      // Create an existing PRD file with matching title
+      // Create state with processed item - use correct hash
+      const statePath = getStateFilePath(prdDir);
+      const state = {
+        version: 1,
+        lastScan: "",
+        items: {
+          [computeHash("Done Feature")]: {
+            title: "Done Feature",
+            prdFile: "01-done-feature.md",
+            createdAt: new Date().toISOString(),
+          },
+        },
+      };
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2));
+
+      // No need to mock - spawn won't be called
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+      const result = await sliceNextItem(tempDir, config);
+
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("No pending items");
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("sliceRoadmapItem", () => {
+    it("sliceRoadmapItem should detect duplicate by slug", async () => {
+      // Create existing PRD with matching slug
       fs.writeFileSync(path.join(prdDir, "05-existing-feature.md"), "# PRD: Existing Feature\n");
 
-      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const item: IRoadmapItem = {
+        hash: "abc12345",
+        title: "Existing Feature",
+        description: "Some description",
+        checked: false,
+        section: "Features",
+      };
 
-      expect(result.created).toHaveLength(0);
-      expect(result.skipped).toHaveLength(1);
-      expect(result.skipped[0]).toContain("duplicate by title");
+      // No need to mock - spawn won't be called for duplicate
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+      const result = await sliceRoadmapItem(tempDir, prdDir, item, config);
+
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("Duplicate detected");
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
     });
 
-    it("should use correct numbering for new PRDs", () => {
+    it("sliceRoadmapItem should not update state on provider failure", async () => {
+      const item: IRoadmapItem = {
+        hash: "fail1234",
+        title: "Failed Feature",
+        description: "This will fail",
+        checked: false,
+        section: "Features",
+      };
+
+      // Mock provider to fail
+      mockProviderFailure();
+
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+
+      // Get initial state
+      const stateBefore = loadRoadmapState(prdDir);
+      const processedCountBefore = Object.keys(stateBefore.items).length;
+
+      const result = await sliceRoadmapItem(tempDir, prdDir, item, config);
+
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("exited with code 1");
+
+      // State should be unchanged
+      const stateAfter = loadRoadmapState(prdDir);
+      expect(Object.keys(stateAfter.items).length).toBe(processedCountBefore);
+    });
+
+    it("sliceRoadmapItem should succeed when provider creates file", async () => {
+      const item: IRoadmapItem = {
+        hash: "succ12345",
+        title: "Success Feature",
+        description: "This will succeed",
+        checked: false,
+        section: "Features",
+      };
+
+      // Mock provider to succeed
+      mockProviderSuccess("01-success-feature.md");
+
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+      const result = await sliceRoadmapItem(tempDir, prdDir, item, config);
+
+      expect(result.sliced).toBe(true);
+      expect(result.file).toBe("01-success-feature.md");
+
+      // Verify file was created
+      expect(fs.existsSync(path.join(prdDir, "01-success-feature.md"))).toBe(true);
+    });
+
+    it("sliceRoadmapItem should fail when provider succeeds but does not create file", async () => {
+      const item: IRoadmapItem = {
+        hash: "nofil1234",
+        title: "No File Feature",
+        description: "No file will be created",
+        checked: false,
+        section: "Features",
+      };
+
+      // Mock provider to succeed but not create file
+      mockProviderNoFile();
+
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+      const result = await sliceRoadmapItem(tempDir, prdDir, item, config);
+
+      expect(result.sliced).toBe(false);
+      expect(result.error).toContain("did not create expected file");
+    });
+  });
+
+  describe("scanRoadmap (async)", () => {
+    it("scanRoadmap should process only one item", async () => {
       fs.writeFileSync(
         roadmapPath,
         `## Features
-- [ ] Feature A
-- [ ] Feature B
+- [ ] Feature One
+- [ ] Feature Two
 `
       );
 
-      // Create existing PRD with number 05
-      fs.writeFileSync(path.join(prdDir, "05-existing.md"), "# PRD: Existing\n");
+      mockProviderSuccess("01-feature-one.md");
 
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const result = await scanRoadmap(tempDir, config);
 
-      expect(result.created).toHaveLength(2);
-      expect(result.created).toContain("06-feature-a.md");
-      expect(result.created).toContain("07-feature-b.md");
+      // Should only process ONE item at most
+      expect(result.created.length).toBeLessThanOrEqual(1);
+      expect(result.created[0]).toBe("01-feature-one.md");
     });
 
-    it("should handle empty roadmap", () => {
+    it("should handle empty roadmap", async () => {
       fs.writeFileSync(roadmapPath, `## Features\n`);
 
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const result = await scanRoadmap(tempDir, config);
 
       expect(result.created).toHaveLength(0);
       expect(result.skipped).toHaveLength(0);
       expect(result.errors).toHaveLength(0);
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
     });
 
-    it("should handle heading-based items", () => {
-      fs.writeFileSync(
-        roadmapPath,
-        `## Features
-
-### Implement Feature X
-
-This is a detailed description.
-It has multiple lines.
-
-### Add Feature Y
-
-Another description.
-`
-      );
-
-      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
-
-      expect(result.created).toHaveLength(2);
-      expect(result.created).toContain("01-implement-feature-x.md");
-      expect(result.created).toContain("02-add-feature-y.md");
-
-      // Verify content of first PRD
-      const content = fs.readFileSync(path.join(prdDir, "01-implement-feature-x.md"), "utf-8");
-      expect(content).toContain("# PRD: Implement Feature X");
-    });
-
-    it("should do nothing when scanner disabled", () => {
+    it("should do nothing when scanner disabled", async () => {
       fs.writeFileSync(roadmapPath, `## Features\n- [ ] Feature A\n`);
 
       const config = {
         ...disabledConfig,
         prdDir: path.relative(tempDir, prdDir),
       };
-      const result = scanRoadmap(tempDir, config);
+      const result = await scanRoadmap(tempDir, config);
 
       expect(result.created).toHaveLength(0);
       expect(result.skipped).toHaveLength(0);
+      // Verify spawn was not called
+      expect(childProcess.spawn).not.toHaveBeenCalled();
     });
 
-    it("should handle special characters in title", () => {
+    it("should handle special characters in title", async () => {
       fs.writeFileSync(
         roadmapPath,
         `## Features
@@ -332,12 +484,26 @@ Another description.
 `
       );
 
+      mockProviderSuccess("01-feature-with-special-characters-symbols.md");
+
       const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
-      const result = scanRoadmap(tempDir, config);
+      const result = await scanRoadmap(tempDir, config);
 
       expect(result.created).toHaveLength(1);
-      // slugify should convert special chars to hyphens
       expect(result.created[0]).toMatch(/01-feature-with-special-characters-symbols\.md/);
+    });
+
+    it("should return error when provider fails", async () => {
+      fs.writeFileSync(roadmapPath, `## Features\n- [ ] Failed Feature\n`);
+
+      mockProviderFailure();
+
+      const config = { ...defaultConfig, prdDir: path.relative(tempDir, prdDir) };
+      const result = await scanRoadmap(tempDir, config);
+
+      expect(result.created).toHaveLength(0);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain("exited with code");
     });
   });
 });

--- a/src/__tests__/templates/slicer-prompt.test.ts
+++ b/src/__tests__/templates/slicer-prompt.test.ts
@@ -1,0 +1,227 @@
+/**
+ * Tests for the Slicer Prompt Template rendering system
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  renderSlicerPrompt,
+  loadSlicerTemplate,
+  clearTemplateCache,
+  createSlicerPromptVars,
+  ISlicerPromptVars,
+} from "../../templates/slicer-prompt.js";
+
+function createTestVars(overrides: Partial<ISlicerPromptVars> = {}): ISlicerPromptVars {
+  return {
+    title: "Test Feature",
+    section: "Features",
+    description: "A test feature description",
+    outputFilePath: "/path/to/prds/01-test-feature.md",
+    prdDir: "/path/to/prds",
+    ...overrides,
+  };
+}
+
+describe("slicer-prompt", () => {
+  beforeEach(() => {
+    // Clear the template cache before each test
+    clearTemplateCache();
+  });
+
+  describe("renderSlicerPrompt", () => {
+    it("should interpolate all placeholders", () => {
+      const vars = createTestVars({
+        title: "My Awesome Feature",
+        section: "Roadmap",
+        description: "This feature does amazing things",
+        outputFilePath: "/project/docs/PRDs/42-awesome.md",
+        prdDir: "/project/docs/PRDs",
+      });
+
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toContain("My Awesome Feature");
+      expect(result).toContain("Roadmap");
+      expect(result).toContain("This feature does amazing things");
+      expect(result).toContain("/project/docs/PRDs/42-awesome.md");
+      expect(result).toContain("/project/docs/PRDs");
+    });
+
+    it("should not contain any uninterpolated placeholders", () => {
+      const vars = createTestVars();
+
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).not.toContain("{{");
+      expect(result).not.toContain("}}");
+    });
+
+    it("should include prd-creator template structure", () => {
+      const vars = createTestVars();
+
+      const result = renderSlicerPrompt(vars);
+
+      // Check for key PRD structure elements
+      expect(result).toContain("Complexity");
+      expect(result).toContain("Execution Phases");
+      expect(result).toContain("Context");
+      expect(result).toContain("Solution");
+      expect(result).toContain("Acceptance Criteria");
+    });
+
+    it("should include complexity scoring guide", () => {
+      const vars = createTestVars();
+
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toContain("COMPLEXITY SCORE");
+      expect(result).toContain("Touches 1-5 files");
+      expect(result).toContain("LOW");
+      expect(result).toContain("MEDIUM");
+      expect(result).toContain("HIGH");
+    });
+
+    it("should include instructions to write the file", () => {
+      const vars = createTestVars({
+        outputFilePath: "/custom/path/feature.md",
+      });
+
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toContain("/custom/path/feature.md");
+      expect(result).toContain("Write tool");
+    });
+
+    it("should use custom template when provided", () => {
+      const vars = createTestVars({ title: "Custom Title" });
+      const customTemplate = "Custom Prompt: {{TITLE}} in {{SECTION}}";
+
+      const result = renderSlicerPrompt(vars, customTemplate);
+
+      expect(result).toBe("Custom Prompt: Custom Title in Features");
+    });
+
+    it("should handle empty description", () => {
+      const vars = createTestVars({ description: "" });
+
+      const result = renderSlicerPrompt(vars);
+
+      // Should still render without errors
+      expect(result).toContain("Test Feature");
+      expect(result).not.toContain("{{DESCRIPTION}}");
+    });
+
+    it("should handle special characters in values", () => {
+      const vars = createTestVars({
+        title: "Feature with `backticks` and $pecial chars",
+        description: "Description with\nnewlines\nand **markdown**",
+      });
+
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toContain("Feature with `backticks` and $pecial chars");
+      expect(result).toContain("Description with\nnewlines\nand **markdown**");
+    });
+  });
+
+  describe("loadSlicerTemplate", () => {
+    it("should load template from file", () => {
+      const template = loadSlicerTemplate();
+
+      expect(template).toContain("PRD Creator Agent");
+      expect(template).toContain("{{TITLE}}");
+      expect(template).toContain("{{SECTION}}");
+      expect(template).toContain("{{DESCRIPTION}}");
+      expect(template).toContain("{{OUTPUT_FILE_PATH}}");
+      expect(template).toContain("{{PRD_DIR}}");
+    });
+
+    it("should cache the template", () => {
+      const template1 = loadSlicerTemplate();
+      const template2 = loadSlicerTemplate();
+
+      // Should return the same reference (cached)
+      expect(template1).toBe(template2);
+    });
+
+    it("should clear cache when requested", () => {
+      loadSlicerTemplate();
+      clearTemplateCache();
+
+      // After clearing, next load should be fresh
+      // (We can't directly test this, but at least verify it doesn't throw)
+      const template = loadSlicerTemplate();
+      expect(template).toBeTruthy();
+    });
+  });
+
+  describe("createSlicerPromptVars", () => {
+    it("should create variables with correct paths", () => {
+      const vars = createSlicerPromptVars(
+        "Feature Title",
+        "Section Name",
+        "Feature description",
+        "/path/to/prds",
+        "99-feature-title.md",
+      );
+
+      expect(vars.title).toBe("Feature Title");
+      expect(vars.section).toBe("Section Name");
+      expect(vars.description).toBe("Feature description");
+      expect(vars.prdDir).toBe("/path/to/prds");
+      expect(vars.outputFilePath).toBe("/path/to/prds/99-feature-title.md");
+    });
+
+    it("should handle empty description with default", () => {
+      const vars = createSlicerPromptVars(
+        "Feature",
+        "Section",
+        "",
+        "/prds",
+        "file.md",
+      );
+
+      expect(vars.description).toBe("(No description provided)");
+    });
+  });
+
+  describe("integration with prd-creator format", () => {
+    it("should produce a prompt that instructs AI to explore the codebase", () => {
+      const vars = createTestVars();
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toMatch(/explore/i);
+      expect(result).toMatch(/codebase/i);
+    });
+
+    it("should produce a prompt that instructs AI to assess complexity", () => {
+      const vars = createTestVars();
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toMatch(/assess.*complexity/i);
+    });
+
+    it("should produce a prompt that instructs AI to write a complete PRD with all required sections", () => {
+      const vars = createTestVars();
+      const result = renderSlicerPrompt(vars);
+
+      expect(result).toMatch(/context/i);
+      expect(result).toMatch(/solution/i);
+      expect(result).toMatch(/phases/i);
+      expect(result).toMatch(/tests/i);
+      expect(result).toMatch(/acceptance.?criteria/i);
+    });
+
+    it("should emphasize the exact output file path", () => {
+      const vars = createTestVars({
+        outputFilePath: "/exact/path/to/prd.md",
+      });
+      const result = renderSlicerPrompt(vars);
+
+      // The output file path should appear multiple times for emphasis
+      const matches = result.match(/\/exact\/path\/to\/prd\.md/g);
+      expect(matches).toBeTruthy();
+      expect(matches!.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import { retryCommand } from './commands/retry.js';
 import { prsCommand } from './commands/prs.js';
 import { prdsCommand } from './commands/prds.js';
 import { cancelCommand } from './commands/cancel.js';
+import { sliceCommand } from './commands/slice.js';
 
 // Get package.json version
 const __filename = fileURLToPath(import.meta.url);
@@ -83,5 +84,8 @@ prdsCommand(program);
 
 // Register cancel command
 cancelCommand(program);
+
+// Register slice command (roadmap slicer)
+sliceCommand(program);
 
 program.parse();

--- a/src/commands/slice.ts
+++ b/src/commands/slice.ts
@@ -1,0 +1,226 @@
+/**
+ * Slice command - executes the roadmap slicer to create PRDs from roadmap items
+ */
+
+import { Command } from "commander";
+import { loadConfig } from "../config.js";
+import { INightWatchConfig, NotificationEvent } from "../types.js";
+import { sendNotifications } from "../utils/notify.js";
+import { PROVIDER_COMMANDS } from "../constants.js";
+import * as path from "path";
+import {
+  createSpinner,
+  createTable,
+  dim,
+  header,
+  info,
+  error as uiError,
+} from "../utils/ui.js";
+import {
+  getRoadmapStatus,
+  sliceNextItem,
+} from "../utils/roadmap-scanner.js";
+import type { ISliceResult } from "../utils/roadmap-scanner.js";
+
+/**
+ * Options for the slice command
+ */
+export interface ISliceOptions {
+  dryRun: boolean;
+  timeout?: string;
+  provider?: string;
+}
+
+/**
+ * Build environment variables map from config and CLI options for slicer
+ */
+export function buildEnvVars(config: INightWatchConfig, options: ISliceOptions): Record<string, string> {
+  const env: Record<string, string> = {};
+
+  // Provider command - the actual CLI binary to call
+  env.NW_PROVIDER_CMD = PROVIDER_COMMANDS[config.provider];
+
+  // Slicer runtime
+  env.NW_SLICER_MAX_RUNTIME = String(config.roadmapScanner.slicerMaxRuntime);
+
+  // PRD directory for slicer output
+  env.NW_PRD_DIR = config.prdDir;
+
+  // Roadmap path
+  env.NW_ROADMAP_PATH = config.roadmapScanner.roadmapPath;
+
+  // Provider environment variables (API keys, base URLs, etc.)
+  if (config.providerEnv) {
+    Object.assign(env, config.providerEnv);
+  }
+
+  // Dry run flag
+  if (options.dryRun) {
+    env.NW_DRY_RUN = "1";
+  }
+
+  // Sandbox flag - prevents the agent from modifying crontab during execution
+  env.NW_EXECUTION_CONTEXT = "agent";
+
+  return env;
+}
+
+/**
+ * Apply CLI flag overrides to the config for slicer
+ */
+export function applyCliOverrides(config: INightWatchConfig, options: ISliceOptions): INightWatchConfig {
+  const overridden = { ...config };
+
+  if (options.timeout) {
+    const timeout = parseInt(options.timeout, 10);
+    if (!isNaN(timeout)) {
+      overridden.roadmapScanner = {
+        ...overridden.roadmapScanner,
+        slicerMaxRuntime: timeout,
+      };
+    }
+  }
+
+  if (options.provider) {
+    overridden.provider = options.provider as INightWatchConfig["provider"];
+  }
+
+  return overridden;
+}
+
+/**
+ * Register the slice command with the program
+ */
+export function sliceCommand(program: Command): void {
+  program
+    .command("slice")
+    .description("Run roadmap slicer to create PRD from next roadmap item")
+    .option("--dry-run", "Show what would be executed without running")
+    .option("--timeout <seconds>", "Override max runtime in seconds for slicer")
+    .option("--provider <string>", "AI provider to use (claude or codex)")
+    .action(async (options: ISliceOptions) => {
+      // Get the project directory (current working directory)
+      const projectDir = process.cwd();
+
+      // Load config from file and environment
+      let config = loadConfig(projectDir);
+
+      // Apply CLI flag overrides
+      config = applyCliOverrides(config, options);
+
+      // Build environment variables
+      const envVars = buildEnvVars(config, options);
+
+      if (options.dryRun) {
+        header("Dry Run: Roadmap Slicer");
+
+        // Configuration section with table
+        header("Configuration");
+        const configTable = createTable({ head: ["Setting", "Value"] });
+        configTable.push(["Provider", config.provider]);
+        configTable.push(["Provider CLI", PROVIDER_COMMANDS[config.provider]]);
+        configTable.push(["PRD Directory", config.prdDir]);
+        configTable.push(["Roadmap Path", config.roadmapScanner.roadmapPath]);
+        configTable.push(["Slicer Max Runtime", `${config.roadmapScanner.slicerMaxRuntime}s (${Math.floor(config.roadmapScanner.slicerMaxRuntime / 60)}min)`]);
+        configTable.push(["Slicer Schedule", config.roadmapScanner.slicerSchedule]);
+        configTable.push(["Scanner Enabled", config.roadmapScanner.enabled ? "Yes" : "No"]);
+        console.log(configTable.toString());
+
+        // Get roadmap status
+        header("Roadmap Status");
+        const roadmapStatus = getRoadmapStatus(projectDir, config);
+
+        if (!config.roadmapScanner.enabled) {
+          dim("  Roadmap scanner is disabled");
+        } else if (roadmapStatus.status === "no-roadmap") {
+          dim(`  ROADMAP.md not found at ${config.roadmapScanner.roadmapPath}`);
+        } else {
+          const statusTable = createTable({ head: ["Metric", "Count"] });
+          statusTable.push(["Total Items", roadmapStatus.totalItems]);
+          statusTable.push(["Processed", roadmapStatus.processedItems]);
+          statusTable.push(["Pending", roadmapStatus.pendingItems]);
+          statusTable.push(["Status", roadmapStatus.status]);
+          console.log(statusTable.toString());
+
+          // Show pending items
+          if (roadmapStatus.pendingItems > 0) {
+            header("Pending Items");
+            const pendingItems = roadmapStatus.items.filter((item) => !item.processed && !item.checked);
+            for (const item of pendingItems.slice(0, 10)) {
+              info(`  - ${item.title}`);
+              if (item.section) {
+                dim(`    Section: ${item.section}`);
+              }
+            }
+            if (pendingItems.length > 10) {
+              dim(`  ... and ${pendingItems.length - 10} more`);
+            }
+          }
+        }
+
+        // Provider invocation command
+        header("Provider Invocation");
+        const providerCmd = PROVIDER_COMMANDS[config.provider];
+        const autoFlag = config.provider === "claude" ? "--dangerously-skip-permissions" : "--yolo";
+        dim(`  ${providerCmd} ${autoFlag} -p "/night-watch-slicer"`);
+
+        // Environment variables
+        header("Environment Variables");
+        for (const [key, value] of Object.entries(envVars)) {
+          dim(`  ${key}=${value}`);
+        }
+
+        // Full command that would be executed
+        header("Action");
+        dim("  Would invoke sliceNextItem() to process one roadmap item");
+        console.log();
+
+        process.exit(0);
+      }
+
+      // Check if roadmap scanner is enabled
+      if (!config.roadmapScanner.enabled) {
+        uiError("Roadmap scanner is disabled. Enable it in night-watch.config.json to use the slicer.");
+        process.exit(1);
+      }
+
+      // Execute the slicer with spinner
+      const spinner = createSpinner("Running roadmap slicer...");
+      spinner.start();
+
+      try {
+        const result: ISliceResult = await sliceNextItem(projectDir, config);
+
+        if (result.sliced) {
+          spinner.succeed(`Slicer completed successfully: Created ${result.file}`);
+        } else if (result.error) {
+          if (result.error === "No pending items to process") {
+            spinner.succeed("No pending items to process");
+          } else {
+            spinner.fail(`Slicer failed: ${result.error}`);
+          }
+        }
+
+        // Send notifications (fire-and-forget, failures do not affect exit code)
+        const exitCode = result.sliced ? 0 : (result.error === "No pending items to process" ? 0 : 1);
+
+        if (!options.dryRun && result.sliced) {
+          const event: NotificationEvent = "run_succeeded";
+
+          await sendNotifications(config, {
+            event,
+            projectName: path.basename(projectDir),
+            exitCode,
+            provider: config.provider,
+            prTitle: result.item?.title,
+          });
+        }
+
+        process.exit(exitCode);
+      } catch (err) {
+        spinner.fail("Failed to execute slice command");
+        uiError(`${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+    });
+}

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -74,7 +74,7 @@ export function performUninstall(
     if (!options?.keepLogs) {
       const logDir = path.join(projectDir, "logs");
       if (fs.existsSync(logDir)) {
-        const logFiles = ["executor.log", "reviewer.log"];
+        const logFiles = ["executor.log", "reviewer.log", "slicer.log"];
         logFiles.forEach((logFile) => {
           const logPath = path.join(logDir, logFile);
           if (fs.existsSync(logPath)) {
@@ -141,7 +141,7 @@ export function uninstallCommand(program: Command): void {
         if (!options.keepLogs) {
           const logDir = path.join(projectDir, "logs");
           if (fs.existsSync(logDir)) {
-            const logFiles = ["executor.log", "reviewer.log"];
+            const logFiles = ["executor.log", "reviewer.log", "slicer.log"];
             let logsRemoved = 0;
 
             logFiles.forEach((logFile) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -192,6 +192,8 @@ function normalizeConfig(rawConfig: Record<string, unknown>): Partial<INightWatc
       enabled: readBoolean(rawRoadmapScanner.enabled) ?? DEFAULT_ROADMAP_SCANNER.enabled,
       roadmapPath: readString(rawRoadmapScanner.roadmapPath) ?? DEFAULT_ROADMAP_SCANNER.roadmapPath,
       autoScanInterval: readNumber(rawRoadmapScanner.autoScanInterval) ?? DEFAULT_ROADMAP_SCANNER.autoScanInterval,
+      slicerSchedule: readString(rawRoadmapScanner.slicerSchedule) ?? DEFAULT_ROADMAP_SCANNER.slicerSchedule,
+      slicerMaxRuntime: readNumber(rawRoadmapScanner.slicerMaxRuntime) ?? DEFAULT_ROADMAP_SCANNER.slicerMaxRuntime,
     };
     // Validate autoScanInterval has minimum of 30 seconds
     if (roadmapScanner.autoScanInterval < 30) {
@@ -451,6 +453,25 @@ export function loadConfig(projectDir: string): INightWatchConfig {
   // NW_TEMPLATES_DIR environment variable
   if (process.env.NW_TEMPLATES_DIR) {
     envConfig.templatesDir = process.env.NW_TEMPLATES_DIR;
+  }
+
+  // NW_SLICER_SCHEDULE environment variable
+  if (process.env.NW_SLICER_SCHEDULE) {
+    envConfig.roadmapScanner = {
+      ...(envConfig.roadmapScanner ?? DEFAULT_ROADMAP_SCANNER),
+      slicerSchedule: process.env.NW_SLICER_SCHEDULE,
+    };
+  }
+
+  // NW_SLICER_MAX_RUNTIME environment variable
+  if (process.env.NW_SLICER_MAX_RUNTIME) {
+    const slicerMaxRuntime = parseInt(process.env.NW_SLICER_MAX_RUNTIME, 10);
+    if (!isNaN(slicerMaxRuntime) && slicerMaxRuntime > 0) {
+      envConfig.roadmapScanner = {
+        ...(envConfig.roadmapScanner ?? DEFAULT_ROADMAP_SCANNER),
+        slicerMaxRuntime,
+      };
+    }
   }
 
   // Merge all configs

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -46,10 +46,15 @@ export const DEFAULT_NOTIFICATIONS: INotificationConfig = { webhooks: [] };
 export const DEFAULT_PRD_PRIORITY: string[] = [];
 
 // Roadmap Scanner Configuration
+export const DEFAULT_SLICER_SCHEDULE = "0 */6 * * *"; // every 6 hours
+export const DEFAULT_SLICER_MAX_RUNTIME = 600; // 10 minutes
+
 export const DEFAULT_ROADMAP_SCANNER: IRoadmapScannerConfig = {
   enabled: false,
   roadmapPath: "ROADMAP.md",
   autoScanInterval: 300,
+  slicerSchedule: DEFAULT_SLICER_SCHEDULE,
+  slicerMaxRuntime: DEFAULT_SLICER_MAX_RUNTIME,
 };
 
 // Templates Configuration

--- a/src/templates/slicer-prompt.ts
+++ b/src/templates/slicer-prompt.ts
@@ -1,0 +1,200 @@
+/**
+ * Slicer Prompt Template
+ *
+ * Provides functionality to render the AI prompt for generating PRDs from roadmap items.
+ * The template is loaded from templates/night-watch-slicer.md and interpolated with
+ * runtime values from the roadmap item being processed.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+/**
+ * Variables needed to render the slicer prompt
+ */
+export interface ISlicerPromptVars {
+  /** The title of the roadmap item */
+  title: string;
+  /** The section/category of the roadmap item */
+  section: string;
+  /** The description of the roadmap item */
+  description: string;
+  /** The full path where the PRD should be written */
+  outputFilePath: string;
+  /** The directory containing PRDs */
+  prdDir: string;
+}
+
+/**
+ * The default slicer prompt template.
+ * This is used if the template file cannot be read.
+ */
+const DEFAULT_SLICER_TEMPLATE = `You are a **PRD Creator Agent**. Your job: analyze the codebase and write a complete Product Requirements Document (PRD) for a feature.
+
+When this activates: \`PRD Creator: Initializing\`
+
+---
+
+## Input
+
+You are creating a PRD for the following roadmap item:
+
+**Section:** {{SECTION}}
+**Title:** {{TITLE}}
+**Description:** {{DESCRIPTION}}
+
+The PRD must be written to this exact file path:
+**Output File:** \`{{OUTPUT_FILE_PATH}}\`
+
+The PRD directory is: \`{{PRD_DIR}}\`
+
+---
+
+## Your Task
+
+1. **Explore the Codebase** - Read relevant existing files to understand the project structure, patterns, and conventions.
+
+2. **Assess Complexity** - Score the complexity using the rubric and determine whether this is LOW, MEDIUM, or HIGH complexity.
+
+3. **Write a Complete PRD** - Create a full PRD following the prd-creator template structure with Context, Solution, Phases, Tests, and Acceptance Criteria.
+
+4. **Write the PRD File** - Use the Write tool to create the PRD file at the exact path specified in \`{{OUTPUT_FILE_PATH}}\`.
+
+---
+
+## Complexity Scoring
+
+\`\`\`
+COMPLEXITY SCORE (sum all that apply):
++1  Touches 1-5 files
++2  Touches 6-10 files
++3  Touches 10+ files
++2  New system/module from scratch
++2  Complex state logic / concurrency
++2  Multi-package changes
++1  Database schema changes
++1  External API integration
+
+| Score | Level  | Template Mode                                   |
+| ----- | ------ | ----------------------------------------------- |
+| 1-3   | LOW    | Minimal (skip sections marked with MEDIUM/HIGH) |
+| 4-6   | MEDIUM | Standard (all sections)                         |
+| 7+    | HIGH   | Full + mandatory checkpoints every phase        |
+\`\`\`
+
+---
+
+## PRD Template Structure
+
+Your PRD MUST follow this exact structure with these sections:
+1. **Context** - Problem, files analyzed, current behavior, integration points
+2. **Solution** - Approach, architecture diagram, key decisions, data changes
+3. **Sequence Flow** (MEDIUM/HIGH) - Mermaid sequence diagram
+4. **Execution Phases** - Concrete phases with files, implementation steps, and tests
+5. **Acceptance Criteria** - Checklist of completion requirements
+
+---
+
+## Critical Instructions
+
+1. **Read all relevant existing files BEFORE writing any code**
+2. **Follow existing patterns in the codebase**
+3. **Write the PRD with concrete file paths and implementation details**
+4. **Include specific test names and assertions**
+5. **Use the Write tool to create the PRD file at \`{{OUTPUT_FILE_PATH}}\`**
+6. **The PRD must be complete and actionable - no TODO placeholders**
+
+DO NOT leave placeholder text like "[Name]" or "[description]" in the final PRD.
+DO NOT skip any sections.
+DO NOT forget to write the file.
+`;
+
+// Cache for the loaded template
+let cachedTemplate: string | null = null;
+
+/**
+ * Load the slicer prompt template from the templates directory.
+ * Falls back to the default template if the file cannot be read.
+ *
+ * @param templateDir - Optional custom template directory
+ * @returns The template string
+ */
+export function loadSlicerTemplate(templateDir?: string): string {
+  if (cachedTemplate) {
+    return cachedTemplate;
+  }
+
+  // Determine the template file path
+  const templatePath = templateDir
+    ? path.join(templateDir, "night-watch-slicer.md")
+    : path.resolve(__dirname, "..", "..", "templates", "night-watch-slicer.md");
+
+  try {
+    cachedTemplate = fs.readFileSync(templatePath, "utf-8");
+    return cachedTemplate;
+  } catch (_error) {
+    // Fall back to the default template
+    console.warn(
+      `Warning: Could not load slicer template from ${templatePath}, using default`,
+    );
+    return DEFAULT_SLICER_TEMPLATE;
+  }
+}
+
+/**
+ * Clear the cached template (useful for testing)
+ */
+export function clearTemplateCache(): void {
+  cachedTemplate = null;
+}
+
+/**
+ * Render the slicer prompt by interpolating the template with the provided variables.
+ *
+ * @param vars - The variables to interpolate into the template
+ * @param customTemplate - Optional custom template to use instead of the default
+ * @returns The rendered prompt string
+ */
+export function renderSlicerPrompt(
+  vars: ISlicerPromptVars,
+  customTemplate?: string,
+): string {
+  const template = customTemplate ?? loadSlicerTemplate();
+
+  let result = template;
+
+  // Replace all placeholders with their values
+  result = result.replace(/\{\{TITLE\}\}/g, vars.title);
+  result = result.replace(/\{\{SECTION\}\}/g, vars.section);
+  result = result.replace(/\{\{DESCRIPTION\}\}/g, vars.description);
+  result = result.replace(/\{\{OUTPUT_FILE_PATH\}\}/g, vars.outputFilePath);
+  result = result.replace(/\{\{PRD_DIR\}\}/g, vars.prdDir);
+
+  return result;
+}
+
+/**
+ * Create slicer prompt variables from a roadmap item.
+ *
+ * @param item - The roadmap item title
+ * @param section - The roadmap item section
+ * @param description - The roadmap item description
+ * @param prdDir - The PRD directory path
+ * @param prdFilename - The filename for the new PRD
+ * @returns The slicer prompt variables
+ */
+export function createSlicerPromptVars(
+  title: string,
+  section: string,
+  description: string,
+  prdDir: string,
+  prdFilename: string,
+): ISlicerPromptVars {
+  return {
+    title,
+    section,
+    description: description || "(No description provided)",
+    outputFilePath: path.join(prdDir, prdFilename),
+    prdDir,
+  };
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,4 +102,10 @@ export interface IRoadmapScannerConfig {
 
   /** Interval in seconds between automatic scans */
   autoScanInterval: number;
+
+  /** Cron schedule for the slicer (AI-powered PRD generation from roadmap items) */
+  slicerSchedule: string;
+
+  /** Maximum runtime in seconds for the slicer */
+  slicerMaxRuntime: number;
 }

--- a/templates/night-watch-slicer.md
+++ b/templates/night-watch-slicer.md
@@ -1,0 +1,219 @@
+You are a **PRD Creator Agent**. Your job: analyze the codebase and write a complete Product Requirements Document (PRD) for a feature.
+
+When this activates: `PRD Creator: Initializing`
+
+---
+
+## Input
+
+You are creating a PRD for the following roadmap item:
+
+**Section:** {{SECTION}}
+**Title:** {{TITLE}}
+**Description:** {{DESCRIPTION}}
+
+The PRD must be written to this exact file path:
+**Output File:** `{{OUTPUT_FILE_PATH}}`
+
+The PRD directory is: `{{PRD_DIR}}`
+
+---
+
+## Your Task
+
+1. **Explore the Codebase** - Read relevant existing files to understand the project structure, patterns, and conventions. Look for:
+   - CLAUDE.md or similar AI assistant documentation files
+   - Existing code patterns in the area you'll be modifying
+   - Related features or modules that this feature interacts with
+   - Test patterns and verification commands
+
+2. **Assess Complexity** - Score the complexity using the rubric below and determine whether this is LOW, MEDIUM, or HIGH complexity.
+
+3. **Write a Complete PRD** - Create a full PRD following the template structure below. The PRD must be actionable, with concrete file paths, implementation steps, and test specifications.
+
+4. **Write the PRD File** - Use the Write tool to create the PRD file at the exact path specified in `{{OUTPUT_FILE_PATH}}`.
+
+---
+
+## Complexity Scoring
+
+```
+COMPLEXITY SCORE (sum all that apply):
++1  Touches 1-5 files
++2  Touches 6-10 files
++3  Touches 10+ files
++2  New system/module from scratch
++2  Complex state logic / concurrency
++2  Multi-package changes
++1  Database schema changes
++1  External API integration
+
+| Score | Level  | Template Mode                                   |
+| ----- | ------ | ----------------------------------------------- |
+| 1-3   | LOW    | Minimal (skip sections marked with MEDIUM/HIGH) |
+| 4-6   | MEDIUM | Standard (all sections)                         |
+| 7+    | HIGH   | Full + mandatory checkpoints every phase        |
+```
+
+---
+
+## PRD Template Structure
+
+Your PRD MUST follow this exact structure:
+
+```markdown
+# PRD: [Title from roadmap item]
+
+**Depends on:** [List any prerequisite PRDs/files, or omit if none]
+
+**Complexity: [SCORE] → [LEVEL] mode**
+
+- [Complexity breakdown as bullet list]
+
+---
+
+## 1. Context
+
+**Problem:** [1-2 sentences describing the issue being solved]
+
+**Files Analyzed:**
+- `path/to/file.ts` — [what the file does]
+- [List all files you inspected before planning]
+
+**Current Behavior:**
+- [3-5 bullets describing current state]
+
+### Integration Points Checklist
+
+**How will this feature be reached?**
+- [ ] Entry point identified: [e.g., route, event, cron, CLI command]
+- [ ] Caller file identified: [file that will invoke this new code]
+- [ ] Registration/wiring needed: [e.g., add route to router, register handler, add menu item]
+
+**Is this user-facing?**
+- [ ] YES → UI components required (list them)
+- [ ] NO → Internal/background feature (explain how it's triggered)
+
+**Full user flow:**
+1. User does: [action]
+2. Triggers: [what code path]
+3. Reaches new feature via: [specific connection point]
+4. Result displayed in: [where user sees outcome]
+
+---
+
+## 2. Solution
+
+**Approach:**
+- [3-5 bullets explaining the chosen solution]
+
+**Architecture Diagram** <!-- (MEDIUM/HIGH complexity) -->:
+
+```mermaid
+flowchart LR
+    A[Component A] --> B[Component B] --> C[Component C]
+```
+
+**Key Decisions:**
+- [Library/framework choices, error-handling strategy, reused utilities]
+
+**Data Changes:** [New schemas/migrations, or "None"]
+
+---
+
+## 3. Sequence Flow <!-- (MEDIUM/HIGH complexity) -->
+
+```mermaid
+sequenceDiagram
+    participant A as Component A
+    participant B as Component B
+    A->>B: methodName(args)
+    alt Error case
+        B-->>A: ErrorType
+    else Success
+        B-->>A: Response
+    end
+```
+
+---
+
+## 4. Execution Phases
+
+**CRITICAL RULES:**
+1. Each phase = ONE user-testable vertical slice
+2. Max 5 files per phase (split if larger)
+3. Each phase MUST include concrete tests
+4. Checkpoint after each phase (automated ALWAYS required)
+
+### Phase 1: [Name] — [User-visible outcome in 1 sentence]
+
+**Files (max 5):**
+- `src/path/file.ts` — [what changes]
+
+**Implementation:**
+- [ ] Step 1
+- [ ] Step 2
+
+**Tests Required:**
+| Test File | Test Name | Assertion |
+|-----------|-----------|-----------|
+| `src/__tests__/feature.test.ts` | `should do X when Y` | `expect(result).toBe(Z)` |
+
+**Verification Plan:**
+1. **Unit Tests:** File and test names
+2. **Integration Test:** (if applicable)
+3. **User Verification:**
+   - Action: [what to do]
+   - Expected: [what should happen]
+
+**Checkpoint:** Run automated review after this phase completes.
+
+---
+
+[Repeat for additional phases as needed]
+
+---
+
+## 5. Acceptance Criteria
+
+- [ ] All phases complete
+- [ ] All specified tests pass
+- [ ] Verification commands pass
+- [ ] All automated checkpoint reviews passed
+- [ ] Feature is reachable (entry point connected, not orphaned code)
+- [ ] [additional criterion specific to this feature]
+- [ ] [additional criterion specific to this feature]
+```
+
+---
+
+## Critical Instructions
+
+1. **Read all relevant existing files BEFORE writing any code**
+2. **Follow existing patterns in the codebase**
+3. **Write the PRD with concrete file paths and implementation details**
+4. **Include specific test names and assertions**
+5. **Use the Write tool to create the PRD file at `{{OUTPUT_FILE_PATH}}`**
+6. **The PRD must be complete and actionable - no TODO placeholders**
+
+DO NOT leave placeholder text like "[Name]" or "[description]" in the final PRD.
+DO NOT skip any sections.
+DO NOT forget to write the file.
+
+---
+
+## Output
+
+After writing the PRD file, report:
+
+```markdown
+## PRD Creation Complete
+
+**File:** {{OUTPUT_FILE_PATH}}
+**Title:** [PRD title]
+**Complexity:** [score] → [level]
+**Phases:** [count]
+
+### Summary
+[1-2 sentences summarizing the PRD content]
+```


### PR DESCRIPTION
## Summary

Adds a third autonomous process ("slicer") alongside executor and reviewer that invokes AI provider to generate full PRDs from roadmap items.

### Key Changes

- **Config types**: Added `slicerSchedule` (default: every 6 hours) and `slicerMaxRuntime` (default: 10 minutes)
- **Slicer template**: Created `templates/night-watch-slicer.md` with full prd-creator format
- **Core engine**: Added `sliceNextItem()` and `sliceRoadmapItem()` async functions that spawn AI provider CLI
- **CLI command**: `night-watch slice` with `--dry-run`, `--timeout`, `--provider` options
- **Cron script**: `night-watch-slicer-cron.sh` with lock file support
- **Install integration**: Slicer crontab entry added when `roadmapScanner.enabled: true`
- **Web API**: Updated scan endpoint to process one item at a time

### How It Works

1. The slicer reads ROADMAP.md and finds the first unprocessed, unchecked item
2. It builds a prompt using the prd-creator template format
3. It spawns the configured AI provider (claude/codex) with the prompt
4. The AI writes the PRD file to the expected path
5. On success, `.roadmap-state.json` is updated to track the processed item

### Files Changed

| File | Change |
|------|--------|
| `src/types.ts` | Added `slicerSchedule`, `slicerMaxRuntime` to `IRoadmapScannerConfig` |
| `src/constants.ts` | Added defaults for slicer config |
| `src/config.ts` | Added env var parsing for `NW_SLICER_*` |
| `src/utils/roadmap-scanner.ts` | Added `sliceNextItem()`, `sliceRoadmapItem()`, updated `scanRoadmap()` to async |
| `src/commands/slice.ts` | **NEW** CLI command |
| `scripts/night-watch-slicer-cron.sh` | **NEW** cron script |
| `templates/night-watch-slicer.md` | **NEW** prompt template |
| `src/templates/slicer-prompt.ts` | **NEW** template interpolation |
| `src/commands/install.ts` | Added slicer crontab entry |
| `src/commands/uninstall.ts` | Added slicer.log cleanup |
| `src/server/index.ts` | Updated scan endpoint for async |
| `src/cli.ts` | Registered slice command |
| Tests | 87 new/updated tests |

## Test plan

- [x] `yarn verify` passes
- [x] All 87 PRD-related tests pass
- [x] `night-watch slice --dry-run` shows roadmap status
- [x] `night-watch install` adds slicer crontab entry when scanner enabled
- [x] `night-watch install --no-slicer` skips slicer entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)