### PR TITLE
feat: add auto-merge for PRs passing CI and review score

### DIFF
--- a/src/__tests__/commands/review.test.ts
+++ b/src/__tests__/commands/review.test.ts
@@ -250,6 +250,15 @@ describe("review command", () => {
 
       expect(overridden.autoMerge).toBe(true);
     });
+
+    it("should allow --auto-merge flag to disable autoMerge", () => {
+      const config = createTestConfig({ autoMerge: true });
+      const options: IReviewOptions = { dryRun: false, autoMerge: false };
+
+      const overridden = applyCliOverrides(config, options);
+
+      expect(overridden.autoMerge).toBe(false);
+    });
   });
 
   describe("notification integration", () => {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -473,6 +473,145 @@ describe("config", () => {
     });
   });
 
+  describe("autoMerge config", () => {
+    it("should default autoMerge to false", () => {
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(false);
+    });
+
+    it("should default autoMergeMethod to squash", () => {
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMergeMethod).toBe("squash");
+    });
+
+    it("should load autoMerge from config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMerge: true,
+        })
+      );
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(true);
+    });
+
+    it("should load autoMergeMethod from config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMergeMethod: "merge",
+        })
+      );
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMergeMethod).toBe("merge");
+    });
+
+    it("should handle NW_AUTO_MERGE env var with true", () => {
+      process.env.NW_AUTO_MERGE = "true";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(true);
+    });
+
+    it("should handle NW_AUTO_MERGE env var with 1", () => {
+      process.env.NW_AUTO_MERGE = "1";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(true);
+    });
+
+    it("should handle NW_AUTO_MERGE env var with false", () => {
+      // First set autoMerge to true in config file
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMerge: true,
+        })
+      );
+
+      process.env.NW_AUTO_MERGE = "false";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(false);
+    });
+
+    it("should handle NW_AUTO_MERGE_METHOD env var with valid values", () => {
+      process.env.NW_AUTO_MERGE_METHOD = "rebase";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMergeMethod).toBe("rebase");
+    });
+
+    it("should reject invalid merge method from env var", () => {
+      process.env.NW_AUTO_MERGE_METHOD = "invalid";
+
+      const config = loadConfig(tempDir);
+
+      // Should fallback to default
+      expect(config.autoMergeMethod).toBe("squash");
+    });
+
+    it("should reject invalid merge method from config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMergeMethod: "invalid",
+        })
+      );
+
+      const config = loadConfig(tempDir);
+
+      // Should fallback to default
+      expect(config.autoMergeMethod).toBe("squash");
+    });
+
+    it("should let NW_AUTO_MERGE env var override config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMerge: false,
+        })
+      );
+
+      process.env.NW_AUTO_MERGE = "true";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMerge).toBe(true);
+    });
+
+    it("should let NW_AUTO_MERGE_METHOD env var override config file", () => {
+      const configPath = path.join(tempDir, "night-watch.config.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({
+          autoMergeMethod: "merge",
+        })
+      );
+
+      process.env.NW_AUTO_MERGE_METHOD = "rebase";
+
+      const config = loadConfig(tempDir);
+
+      expect(config.autoMergeMethod).toBe("rebase");
+    });
+  });
+
   describe("notifications config", () => {
     it("should load notifications from config file", () => {
       const configPath = path.join(tempDir, "night-watch.config.json");

--- a/src/commands/review.ts
+++ b/src/commands/review.ts
@@ -78,6 +78,12 @@ export function buildEnvVars(config: INightWatchConfig, options: IReviewOptions)
     Object.assign(env, config.providerEnv);
   }
 
+  // Auto-merge configuration
+  if (config.autoMerge) {
+    env.NW_AUTO_MERGE = "1";
+  }
+  env.NW_AUTO_MERGE_METHOD = config.autoMergeMethod;
+
   // Dry run flag
   if (options.dryRun) {
     env.NW_DRY_RUN = "1";

--- a/src/config.ts
+++ b/src/config.ts
@@ -86,6 +86,7 @@ export function getDefaultConfig(): INightWatchConfig {
     autoMerge: DEFAULT_AUTO_MERGE,
     autoMergeMethod: DEFAULT_AUTO_MERGE_METHOD,
 
+
     // Rate-limit fallback
     fallbackOnRateLimit: DEFAULT_FALLBACK_ON_RATE_LIMIT,
     claudeModel: DEFAULT_CLAUDE_MODEL,
@@ -305,6 +306,7 @@ function normalizeConfig(rawConfig: Record<string, unknown>): Partial<INightWatc
       autoInstallPlaywright: readBoolean(rawQa.autoInstallPlaywright) ?? DEFAULT_QA.autoInstallPlaywright,
     };
     normalized.qa = qa;
+  }
   }
 
   return normalized;
@@ -703,6 +705,7 @@ export function loadConfig(projectDir: string): INightWatchConfig {
         branchPatterns: patterns,
       };
     }
+  }
   }
 
   // Merge all configs

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -116,6 +116,11 @@ export const DEFAULT_SLACK_BOT_CONFIG: ISlackBotConfig = {
 // Valid providers
 export const VALID_PROVIDERS: Provider[] = ["claude", "codex"];
 
+// Auto-merge Configuration
+export const DEFAULT_AUTO_MERGE = false;
+export const DEFAULT_AUTO_MERGE_METHOD: MergeMethod = "squash";
+export const VALID_MERGE_METHODS: MergeMethod[] = ["squash", "merge", "rebase"];
+
 // Provider commands configuration
 export const PROVIDER_COMMANDS: Record<Provider, string> = {
   claude: "claude",

--- a/src/types.ts
+++ b/src/types.ts
@@ -137,6 +137,10 @@ export interface IQaConfig {
 
 export type WebhookType = "slack" | "discord" | "telegram";
 export type NotificationEvent = "run_started" | "run_succeeded" | "run_failed" | "run_timeout" | "review_completed" | "pr_auto_merged" | "rate_limit_fallback" | "qa_completed";
+
+/**
+ * Git merge methods for auto-merge
+ */
 export type MergeMethod = "squash" | "merge" | "rebase";
 
 export interface IWebhookConfig {

--- a/templates/night-watch.config.json
+++ b/templates/night-watch.config.json
@@ -28,3 +28,4 @@
     "autoInstallPlaywright": true
   }
 }
+}


### PR DESCRIPTION
## Summary

Add autoMerge configuration option to automatically merge PRs that pass CI checks and meet the review score threshold. This enables a fully hands-off PRD-to-merge pipeline.

### Features
- **autoMerge** config field (default: `false`, off by default for safety)
- **autoMergeMethod** config field (`squash`|`merge`|`rebase`, default: `squash`)
- `--auto-merge` CLI flag to enable for a single run
- `NW_AUTO_MERGE` and `NW_AUTO_MERGE_METHOD` env vars for override
- Uses `gh pr merge --auto --delete-branch` to respect branch protection rules
- `pr_auto_merged` notification event type for webhook integration
- Auto-merge status shown in `status` command and `review --dry-run`

### Configuration Example
```json
{
  "autoMerge": true,
  "autoMergeMethod": "squash"
}
```

### CLI Usage
```bash
# Enable auto-merge for a single run
night-watch review --auto-merge

# View auto-merge status
night-watch status
night-watch review --dry-run
```

### Behavior
- Auto-merge triggers when all open PRs have passing CI AND review score >= threshold
- Uses `--auto` flag which queues the merge (respects branch protection rules)
- Failures are logged but don't fail the reviewer run
- Only targets PRs matching `branchPatterns` (same filter as reviewer)

Closes #16