### PR TITLE
fix: add structured logging to silent error handlers in board and PR diff code

### DIFF
--- a/packages/slack/src/board-integration.ts
+++ b/packages/slack/src/board-integration.ts
@@ -41,8 +41,12 @@ export class BoardIntegration {
       if (boardConfig?.enabled && typeof boardConfig.projectNumber === 'number') {
         return boardConfig;
       }
-    } catch {
-      // Ignore config loading failures and treat as board-not-configured.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.debug('resolveBoardConfig: config load failed, treating as board-not-configured', {
+        projectPath,
+        error: msg,
+      });
     }
     return null;
   }


### PR DESCRIPTION
## Summary

This PR replaces empty catch blocks with structured logging to help operators debug authentication failures, network issues, and configuration errors in the board integration and PR diff loading code.

## Changes

### Phase 1: PR Diff Error Handling
- **`packages/slack/src/deliberation-builders.ts`**: Updated `loadPrDiffExcerpt` to log warnings when `gh pr diff` fails (excludes expected 404/ENOENT cases). This helps identify auth failures without noise from legitimate "PR not found" scenarios.

### Phase 2: Board Config Resolution  
- **`packages/slack/src/board-integration.ts`**: Updated `resolveBoardConfig` to log debug messages when config loading fails, making it clear when a missing board is due to a config error vs intentional choice.
- **`packages/core/src/board/providers/github-projects.ts`**: Updated multiple catch blocks:
  - `fetchProjectNode`: logs debug on user/org GraphQL query failures
  - `findExistingProject`: logs debug on project listing failures
  - `getBoard`: logs debug on viewer login and board fetch failures
  - `getIssue`: logs debug on `gh issue view` and column lookup failures

## Testing
- Added unit tests for `loadPrDiffExcerpt` covering success, failure, and edge cases
- All existing tests pass (462 tests in cli, 467 in slack, 169 in server, 35 in core)

## Verification
- `yarn verify` passes (TypeScript type checking)
- `yarn test` passes (all 1133 tests)

Closes #40