### PR TITLE
fix: add logging to silent catch blocks for better debugging

### DIFF
--- a/packages/core/src/storage/repositories/sqlite/agent-persona.repository.ts
+++ b/packages/core/src/storage/repositories/sqlite/agent-persona.repository.ts
@@ -175,7 +175,11 @@ export class SqliteAgentPersonaRepository implements IAgentPersonaRepository {
       decipher.setAuthTag(tag);
       const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
       return decrypted.toString('utf8');
-    } catch {
+    } catch (error) {
+      console.warn(
+        '[agent-persona] Failed to decrypt secret:',
+        error instanceof Error ? error.message : String(error),
+      );
       return '';
     }
   }

--- a/packages/core/src/utils/crontab.ts
+++ b/packages/core/src/utils/crontab.ts
@@ -43,9 +43,13 @@ export function readCrontab(): string[] {
       .trim()
       .split('\n')
       .filter((line) => line.length > 0);
-  } catch {
+  } catch (error) {
     // crontab -l returns error if no crontab exists
     // This is expected and should return empty array
+    console.warn(
+      '[crontab] Failed to read crontab:',
+      error instanceof Error ? error.message : String(error),
+    );
     return [];
   }
 }
@@ -73,8 +77,11 @@ export function writeCrontab(lines: string[]): void {
         encoding: 'utf-8',
       });
     }
-  } catch {
-    // Ignore backup errors
+  } catch (error) {
+    console.warn(
+      '[crontab] Failed to create backup:',
+      error instanceof Error ? error.message : String(error),
+    );
   }
 
   // Write new crontab via temp file to avoid shell line length limits
@@ -89,8 +96,11 @@ export function writeCrontab(lines: string[]): void {
   } finally {
     try {
       fs.unlinkSync(tmpFile);
-    } catch {
-      /* ignore cleanup errors */
+    } catch (error) {
+      console.warn(
+        '[crontab] Failed to cleanup temp file:',
+        error instanceof Error ? error.message : String(error),
+      );
     }
   }
 }

--- a/packages/server/src/routes/action.routes.ts
+++ b/packages/server/src/routes/action.routes.ts
@@ -103,8 +103,11 @@ function spawnAction(
           projectName: path.basename(projectDir),
           exitCode: 0,
           provider: config.provider,
-        }).catch(() => {
-          /* silently ignore notification errors */
+        }).catch((error) => {
+          console.warn(
+            '[action.routes] Failed to send run_started notification:',
+            error instanceof Error ? error.message : String(error),
+          );
         });
       }
 


### PR DESCRIPTION
Closes #43

## Summary

Added `console.warn` logging to 5 empty catch blocks that were silently swallowing errors, making debugging difficult:

### Files Changed

1. **`packages/core/src/storage/repositories/sqlite/agent-persona.repository.ts`**
   - `decryptSecret` now logs decryption failures with error context

2. **`packages/core/src/utils/crontab.ts`**
   - `readCrontab` now logs when crontab read fails
   - `writeCrontab` backup operation now logs backup failures
   - `writeCrontab` cleanup operation now logs temp file cleanup failures

3. **`packages/server/src/routes/action.routes.ts`**
   - `sendNotifications` for `run_started` events now logs notification failures

### Before
```typescript
} catch {
  return '';
}
```

### After
```typescript
} catch (error) {
  console.warn('[module-name] Operation failed:', error instanceof Error ? error.message : String(error));
  return '';
}
```

## Test Plan
- [x] `yarn verify` passes
- [x] All 631 tests pass across all packages
- [x] No lint errors
- [x] TypeScript compiles successfully