### PR TITLE
fix: replace hardcoded PR badge with dynamic count

### DIFF
--- a/packages/core/src/__tests__/utils/status-data.test.ts
+++ b/packages/core/src/__tests__/utils/status-data.test.ts
@@ -448,10 +448,72 @@ describe("status-data utilities", () => {
       const result = countOpenPRs(tempDir, ["feat/", "night-watch/"]);
       expect(result).toBe(2);
     });
+
+    it("should return 0 when no PRs match branch patterns", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("git rev-parse")) return ".git";
+        if (cmd.includes("which gh")) return "/usr/bin/gh";
+        if (cmd.includes("gh pr list")) {
+          return JSON.stringify([
+            { headRefName: "fix/bugfix", number: 1 },
+            { headRefName: "chore/cleanup", number: 2 },
+          ]);
+        }
+        return "";
+      });
+
+      const result = countOpenPRs(tempDir, ["feat/", "night-watch/"]);
+      expect(result).toBe(0);
+    });
+
+    it("should return 0 when gh pr list returns empty array", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("git rev-parse")) return ".git";
+        if (cmd.includes("which gh")) return "/usr/bin/gh";
+        if (cmd.includes("gh pr list")) {
+          return "[]";
+        }
+        return "";
+      });
+
+      const result = countOpenPRs(tempDir, ["feat/", "night-watch/"]);
+      expect(result).toBe(0);
+    });
   });
 
   describe("collectPrInfo", () => {
     it("should return empty array when not in a git repo", () => {
+      const result = collectPrInfo(tempDir, ["feat/", "night-watch/"]);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when gh returns empty list", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("git rev-parse")) return ".git";
+        if (cmd.includes("which gh")) return "/usr/bin/gh";
+        if (cmd.includes("gh pr list")) {
+          return "[]";
+        }
+        return "";
+      });
+
+      const result = collectPrInfo(tempDir, ["feat/", "night-watch/"]);
+      expect(result).toEqual([]);
+    });
+
+    it("should return empty array when no PRs match branch patterns", () => {
+      vi.mocked(execSync).mockImplementation((cmd: string) => {
+        if (cmd.includes("git rev-parse")) return ".git";
+        if (cmd.includes("which gh")) return "/usr/bin/gh";
+        if (cmd.includes("gh pr list")) {
+          return JSON.stringify([
+            { headRefName: "fix/bugfix", number: 1, title: "Bugfix", url: "https://github.com/test/repo/pull/1" },
+            { headRefName: "chore/cleanup", number: 2, title: "Cleanup", url: "https://github.com/test/repo/pull/2" },
+          ]);
+        }
+        return "";
+      });
+
       const result = collectPrInfo(tempDir, ["feat/", "night-watch/"]);
       expect(result).toEqual([]);
     });

--- a/web/components/Sidebar.tsx
+++ b/web/components/Sidebar.tsx
@@ -12,24 +12,29 @@ import {
   Terminal,
   Users,
 } from 'lucide-react';
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { NavLink } from 'react-router-dom';
+import { useApi, fetchPrs } from '../api';
 import { useStore } from '../store/useStore';
 
 const Sidebar: React.FC = () => {
   const [collapsed, setCollapsed] = useState(false);
-  const { projectName, isGlobalMode, projects, selectedProjectId, selectProject } = useStore();
+  const { projectName, isGlobalMode, projects, selectedProjectId, selectProject, globalModeLoading } = useStore();
 
-  const navItems = [
+  // Fetch PR count for the badge
+  const { data: prs } = useApi(fetchPrs, [selectedProjectId], { enabled: !globalModeLoading });
+  const openPrCount = prs?.length ?? 0;
+
+  const navItems = useMemo(() => [
     { icon: Home, label: 'Dashboard', path: '/' },
     { icon: Kanban, label: 'Board', path: '/board' },
-    { icon: GitPullRequest, label: 'Pull Requests', path: '/prs', badge: 1 },
+    { icon: GitPullRequest, label: 'Pull Requests', path: '/prs', badge: openPrCount },
     { icon: Map, label: 'Roadmap', path: '/roadmap' },
     { icon: Calendar, label: 'Scheduling', path: '/scheduling' },
     { icon: Terminal, label: 'Logs', path: '/logs' },
     { icon: Users, label: 'Agents', path: '/agents' },
     { icon: Settings, label: 'Settings', path: '/settings' },
-  ];
+  ], [openPrCount]);
 
   return (
     <aside


### PR DESCRIPTION
## Summary
Fixes a bug where the Dashboard "Open PRs" card always displayed `1` even when there were no open pull requests.

## Root Cause
The Sidebar component had a hardcoded `badge: 1` for the Pull Requests` navigation item, regardless of the actual number of open PRs.

## Changes
- **web/components/Sidebar.tsx**: Changed hardcoded `badge: 1` to dynamic `badge: openPrCount` by using `useApi(fetchPrs)` to fetch actual PR data
- **packages/core/src/__tests__/utils/status-data.test.ts**: Added comprehensive tests for:
  - Empty array when `gh pr list` returns `[]`
  - Empty array when no PRs match branch patterns
  - Count of 0 when no PRs match patterns
  - Count of 0 when `gh pr list` returns empty array

## Testing
- All existing tests pass
- Added new test cases for edge cases

Closes #53
