### PR TITLE
feat(scheduling): add Queue tab with provider lanes and execution analytics

### DIFF
--- a/packages/cli/src/__tests__/scripts/core-flow-smoke.test.ts
+++ b/packages/cli/src/__tests__/scripts/core-flow-smoke.test.ts
@@ -1539,6 +1539,12 @@ describe('core flow smoke tests (bash scripts)', () => {
       { encoding: 'utf-8', mode: 0o755 },
     );
 
+    fs.writeFileSync(
+      path.join(fakeBin, 'claude'),
+      '#!/usr/bin/env bash\nexit 0\n',
+      { encoding: 'utf-8', mode: 0o755 },
+    );
+
     const result = runScript(reviewerScript, projectDir, {
       PATH: `${fakeBin}:${process.env.PATH}`,
       NW_PROVIDER_CMD: 'claude',
@@ -1593,6 +1599,12 @@ describe('core flow smoke tests (bash scripts)', () => {
         '  exit 0\n' +
         'fi\n' +
         'exit 0\n',
+      { encoding: 'utf-8', mode: 0o755 },
+    );
+
+    fs.writeFileSync(
+      path.join(fakeBin, 'claude'),
+      '#!/usr/bin/env bash\nexit 0\n',
       { encoding: 'utf-8', mode: 0o755 },
     );
 
@@ -1745,6 +1757,12 @@ describe('core flow smoke tests (bash scripts)', () => {
         '  exit 0\n' +
         'fi\n' +
         'exit 0\n',
+      { encoding: 'utf-8', mode: 0o755 },
+    );
+
+    fs.writeFileSync(
+      path.join(fakeBin, 'claude'),
+      '#!/usr/bin/env bash\nexit 0\n',
       { encoding: 'utf-8', mode: 0o755 },
     );
 

--- a/packages/cli/src/commands/review.ts
+++ b/packages/cli/src/commands/review.ts
@@ -166,8 +166,7 @@ export function postReadyForHumanReviewComment(
   finalScore: number | undefined,
   cwd: string,
 ): void {
-  const scoreNote =
-    finalScore !== undefined ? ` (score: ${finalScore}/100)` : '';
+  const scoreNote = finalScore !== undefined ? ` (score: ${finalScore}/100)` : '';
   const body =
     `## ✅ Ready for Human Review\n\n` +
     `Night Watch has reviewed this PR${scoreNote} and found no issues requiring automated fixes.\n\n` +
@@ -520,12 +519,16 @@ export function reviewCommand(program: Command): void {
             const reviewedPrNumbers = parseReviewedPrNumbers(scriptResult?.data.prs);
             const noChangesPrNumbers = parseReviewedPrNumbers(scriptResult?.data.no_changes_prs);
             const fallbackPrNumber = fallbackPrDetails?.number;
+            let primaryPrNumbers: number[];
+            if (reviewedPrNumbers.length > 0) {
+              primaryPrNumbers = reviewedPrNumbers;
+            } else if (fallbackPrNumber !== undefined) {
+              primaryPrNumbers = [fallbackPrNumber];
+            } else {
+              primaryPrNumbers = [];
+            }
             const notificationTargets = buildReviewNotificationTargets(
-              reviewedPrNumbers.length > 0
-                ? reviewedPrNumbers
-                : fallbackPrNumber !== undefined
-                  ? [fallbackPrNumber]
-                  : [],
+              primaryPrNumbers,
               noChangesPrNumbers,
               legacyNoChangesNeeded,
             );
@@ -567,7 +570,10 @@ export function reviewCommand(program: Command): void {
                   event: reviewEvent,
                   projectName: path.basename(projectDir),
                   exitCode,
-                  provider: formatProviderDisplay(envVars.NW_PROVIDER_CMD, envVars.NW_PROVIDER_LABEL),
+                  provider: formatProviderDisplay(
+                    envVars.NW_PROVIDER_CMD,
+                    envVars.NW_PROVIDER_LABEL,
+                  ),
                   prUrl: prDetails?.url,
                   prTitle: prDetails?.title,
                   prBody: prDetails?.body,

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -21,7 +21,6 @@ import {
   DEFAULT_ANALYTICS,
   DEFAULT_AUDIT,
   DEFAULT_AUTO_MERGE,
-  DEFAULT_MERGER,
   DEFAULT_AUTO_MERGE_METHOD,
   DEFAULT_BOARD_PROVIDER,
   DEFAULT_BRANCH_PATTERNS,
@@ -36,6 +35,7 @@ import {
   DEFAULT_MAX_LOG_SIZE,
   DEFAULT_MAX_RETRIES,
   DEFAULT_MAX_RUNTIME,
+  DEFAULT_MERGER,
   DEFAULT_MIN_REVIEW_SCORE,
   DEFAULT_NOTIFICATIONS,
   DEFAULT_PRD_DIR,
@@ -220,7 +220,9 @@ function mergeConfigs(
     merged.merger = {
       ...merged.merger,
       enabled: true,
-      mergeMethod: (merged as unknown as Record<string, unknown>).autoMergeMethod as IMergerConfig['mergeMethod'] ?? 'squash',
+      mergeMethod:
+        ((merged as unknown as Record<string, unknown>)
+          .autoMergeMethod as IMergerConfig['mergeMethod']) ?? 'squash',
     };
   }
 

--- a/web/components/scheduling/QueueTab.tsx
+++ b/web/components/scheduling/QueueTab.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { AlertCircle } from 'lucide-react';
+import Card from '../ui/Card.js';
+import type { IQueueAnalytics, IQueueStatus } from '../../api.js';
+import ProviderLanesChart from './ProviderLanesChart.js';
+import ProviderBucketSummary from './ProviderBucketSummary.js';
+import RecentRunsChart from './RecentRunsChart.js';
+
+interface IQueueTabProps {
+  queueStatus: IQueueStatus | null;
+  queueAnalytics: IQueueAnalytics | null;
+  queueStatusError: Error | null;
+  queueAnalyticsError: Error | null;
+}
+
+const QueueTab: React.FC<IQueueTabProps> = ({
+  queueStatus,
+  queueAnalytics,
+  queueStatusError,
+  queueAnalyticsError,
+}) => {
+  return (
+    <div className="space-y-6">
+      {/* Queue Overview Card */}
+      <Card className="p-6">
+        <h3 className="text-lg font-semibold text-slate-200 mb-4">Queue Overview</h3>
+        {queueStatusError ? (
+          <div className="flex items-center gap-2 text-red-400 py-4">
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-sm">Failed to load queue status</span>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+              <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Running</div>
+              <div className="text-2xl font-bold text-green-400">
+                {queueStatus?.running ? 1 : 0}
+              </div>
+              {queueStatus?.running && (
+                <div className="text-xs text-slate-400 mt-1 truncate" title={queueStatus.running.projectName}>
+                  {queueStatus.running.jobType} · {queueStatus.running.projectName}
+                </div>
+              )}
+            </div>
+            <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+              <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Pending</div>
+              <div className="text-2xl font-bold text-blue-400">
+                {queueStatus?.pending.total ?? 0}
+              </div>
+            </div>
+            <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+              <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Avg Wait</div>
+              <div className="text-2xl font-bold text-slate-200">
+                {queueStatus?.averageWaitSeconds != null
+                  ? `${Math.floor(queueStatus.averageWaitSeconds / 60)}m`
+                  : '—'}
+              </div>
+            </div>
+            <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+              <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Oldest Pending</div>
+              <div className="text-2xl font-bold text-slate-200">
+                {queueStatus?.oldestPendingAge != null
+                  ? `${Math.floor(queueStatus.oldestPendingAge / 60)}m`
+                  : '—'}
+              </div>
+            </div>
+          </div>
+        )}
+      </Card>
+
+      {/* Provider Lanes */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-200">Provider Lanes</h3>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Running and pending jobs grouped by provider bucket
+            </p>
+          </div>
+        </div>
+        {queueStatusError ? (
+          <div className="flex items-center gap-2 text-red-400 py-2">
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-sm">Failed to load queue status</span>
+          </div>
+        ) : queueStatus ? (
+          <ProviderLanesChart status={queueStatus} />
+        ) : (
+          <div className="text-sm text-slate-500 py-2">Loading queue status...</div>
+        )}
+      </Card>
+
+      {/* Provider Bucket Summary */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-200">Provider Buckets</h3>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Running and pending counts per provider bucket
+            </p>
+          </div>
+        </div>
+        {queueAnalyticsError ? (
+          <div className="flex items-center gap-2 text-red-400 py-2">
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-sm">Failed to load analytics</span>
+          </div>
+        ) : queueAnalytics ? (
+          <ProviderBucketSummary analytics={queueAnalytics} />
+        ) : (
+          <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
+        )}
+      </Card>
+
+      {/* Recent Runs */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-slate-200">Recent Runs</h3>
+            <p className="text-xs text-slate-500 mt-0.5">
+              Last 24 hours of job executions
+            </p>
+          </div>
+          {queueAnalytics?.averageWaitSeconds != null && (
+            <div className="text-xs text-slate-500">
+              Avg wait: {Math.floor(queueAnalytics.averageWaitSeconds / 60)}m
+            </div>
+          )}
+        </div>
+        {queueAnalyticsError ? (
+          <div className="flex items-center gap-2 text-red-400 py-2">
+            <AlertCircle className="h-4 w-4" />
+            <span className="text-sm">Failed to load analytics</span>
+          </div>
+        ) : queueAnalytics ? (
+          <RecentRunsChart analytics={queueAnalytics} />
+        ) : (
+          <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default QueueTab;

--- a/web/components/scheduling/QueueTab.tsx
+++ b/web/components/scheduling/QueueTab.tsx
@@ -6,6 +6,18 @@ import ProviderLanesChart from './ProviderLanesChart.js';
 import ProviderBucketSummary from './ProviderBucketSummary.js';
 import RecentRunsChart from './RecentRunsChart.js';
 
+const ERROR_MESSAGES = {
+  queueStatus: 'Failed to load queue status',
+  analytics: 'Failed to load analytics',
+} as const;
+
+const ErrorMessage: React.FC<{ message: string; className?: string }> = ({ message, className }) => (
+  <div className={`flex items-center gap-2 text-red-400 ${className ?? 'py-2'}`}>
+    <AlertCircle className="h-4 w-4" />
+    <span className="text-sm">{message}</span>
+  </div>
+);
+
 interface IQueueTabProps {
   queueStatus: IQueueStatus | null;
   queueAnalytics: IQueueAnalytics | null;
@@ -25,10 +37,7 @@ const QueueTab: React.FC<IQueueTabProps> = ({
       <Card className="p-6">
         <h3 className="text-lg font-semibold text-slate-200 mb-4">Queue Overview</h3>
         {queueStatusError ? (
-          <div className="flex items-center gap-2 text-red-400 py-4">
-            <AlertCircle className="h-4 w-4" />
-            <span className="text-sm">Failed to load queue status</span>
-          </div>
+          <ErrorMessage message={ERROR_MESSAGES.queueStatus} className="py-4" />
         ) : (
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
@@ -79,10 +88,7 @@ const QueueTab: React.FC<IQueueTabProps> = ({
           </div>
         </div>
         {queueStatusError ? (
-          <div className="flex items-center gap-2 text-red-400 py-2">
-            <AlertCircle className="h-4 w-4" />
-            <span className="text-sm">Failed to load queue status</span>
-          </div>
+          <ErrorMessage message={ERROR_MESSAGES.queueStatus} />
         ) : queueStatus ? (
           <ProviderLanesChart status={queueStatus} />
         ) : (
@@ -101,10 +107,7 @@ const QueueTab: React.FC<IQueueTabProps> = ({
           </div>
         </div>
         {queueAnalyticsError ? (
-          <div className="flex items-center gap-2 text-red-400 py-2">
-            <AlertCircle className="h-4 w-4" />
-            <span className="text-sm">Failed to load analytics</span>
-          </div>
+          <ErrorMessage message={ERROR_MESSAGES.analytics} />
         ) : queueAnalytics ? (
           <ProviderBucketSummary analytics={queueAnalytics} />
         ) : (
@@ -128,10 +131,7 @@ const QueueTab: React.FC<IQueueTabProps> = ({
           )}
         </div>
         {queueAnalyticsError ? (
-          <div className="flex items-center gap-2 text-red-400 py-2">
-            <AlertCircle className="h-4 w-4" />
-            <span className="text-sm">Failed to load analytics</span>
-          </div>
+          <ErrorMessage message={ERROR_MESSAGES.analytics} />
         ) : queueAnalytics ? (
           <RecentRunsChart analytics={queueAnalytics} />
         ) : (

--- a/web/pages/Scheduling.tsx
+++ b/web/pages/Scheduling.tsx
@@ -22,9 +22,7 @@ import Select from '../components/ui/Select';
 import Switch from '../components/ui/Switch';
 import Tabs from '../components/ui/Tabs';
 import ScheduleTimeline from '../components/scheduling/ScheduleTimeline.js';
-import ProviderLanesChart from '../components/scheduling/ProviderLanesChart.js';
-import ProviderBucketSummary from '../components/scheduling/ProviderBucketSummary.js';
-import RecentRunsChart from '../components/scheduling/RecentRunsChart.js';
+import QueueTab from '../components/scheduling/QueueTab.js';
 import { useStore } from '../store/useStore';
 import type { INightWatchConfig, IQueueAnalytics, IQueueStatus, QueueMode } from '../api';
 import {
@@ -97,6 +95,8 @@ const Scheduling: React.FC = () => {
   const [allProjectConfigs, setAllProjectConfigs] = useState<Array<{ projectId: string; config: INightWatchConfig }>>([]);
   const [queueStatus, setQueueStatus] = useState<IQueueStatus | null>(null);
   const [queueAnalytics, setQueueAnalytics] = useState<IQueueAnalytics | null>(null);
+  const [queueStatusError, setQueueStatusError] = useState<Error | null>(null);
+  const [queueAnalyticsError, setQueueAnalyticsError] = useState<Error | null>(null);
 
   const [editState, setEditState] = useState<IQueueEditState>({
     isDirty: false,
@@ -142,11 +142,21 @@ const Scheduling: React.FC = () => {
     if (globalModeLoading) return;
     const fetchDashboard = () => {
       fetchQueueStatus()
-        .then(setQueueStatus)
-        .catch(() => { /* silently ignore */ });
+        .then((status) => {
+          setQueueStatus(status);
+          setQueueStatusError(null);
+        })
+        .catch((err) => {
+          setQueueStatusError(err instanceof Error ? err : new Error(String(err)));
+        });
       fetchQueueAnalytics(24)
-        .then(setQueueAnalytics)
-        .catch(() => { /* silently ignore */ });
+        .then((analytics) => {
+          setQueueAnalytics(analytics);
+          setQueueAnalyticsError(null);
+        })
+        .catch((err) => {
+          setQueueAnalyticsError(err instanceof Error ? err : new Error(String(err)));
+        });
     };
     fetchDashboard();
     const interval = setInterval(fetchDashboard, 30000);
@@ -463,7 +473,7 @@ const Scheduling: React.FC = () => {
     return `${activeTemplate.label} - ${activeTemplate.hints[job]}`;
   };
 
-  const tabs = [
+  const tabs = useMemo(() => [
     {
       id: 'overview',
       label: 'Overview',
@@ -920,106 +930,34 @@ const Scheduling: React.FC = () => {
       id: 'queue',
       label: 'Queue',
       content: (
-        <div className="space-y-6">
-          {/* Queue Overview Card */}
-          <Card className="p-6">
-            <h3 className="text-lg font-semibold text-slate-200 mb-4">Queue Overview</h3>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
-                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Running</div>
-                <div className="text-2xl font-bold text-green-400">
-                  {queueStatus?.running ? 1 : 0}
-                </div>
-                {queueStatus?.running && (
-                  <div className="text-xs text-slate-400 mt-1 truncate" title={queueStatus.running.projectName}>
-                    {queueStatus.running.jobType} · {queueStatus.running.projectName}
-                  </div>
-                )}
-              </div>
-              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
-                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Pending</div>
-                <div className="text-2xl font-bold text-blue-400">
-                  {queueStatus?.pending.total ?? 0}
-                </div>
-              </div>
-              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
-                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Avg Wait</div>
-                <div className="text-2xl font-bold text-slate-200">
-                  {queueStatus?.averageWaitSeconds != null
-                    ? `${Math.floor(queueStatus.averageWaitSeconds / 60)}m`
-                    : '—'}
-                </div>
-              </div>
-              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
-                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Oldest Pending</div>
-                <div className="text-2xl font-bold text-slate-200">
-                  {queueStatus?.oldestPendingAge != null
-                    ? `${Math.floor(queueStatus.oldestPendingAge / 60)}m`
-                    : '—'}
-                </div>
-              </div>
-            </div>
-          </Card>
-
-          {/* Provider Lanes */}
-          <Card className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h3 className="text-lg font-semibold text-slate-200">Provider Lanes</h3>
-                <p className="text-xs text-slate-500 mt-0.5">
-                  Running and pending jobs grouped by provider bucket
-                </p>
-              </div>
-            </div>
-            {queueStatus ? (
-              <ProviderLanesChart status={queueStatus} />
-            ) : (
-              <div className="text-sm text-slate-500 py-2">Loading queue status...</div>
-            )}
-          </Card>
-
-          {/* Provider Bucket Summary */}
-          <Card className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h3 className="text-lg font-semibold text-slate-200">Provider Buckets</h3>
-                <p className="text-xs text-slate-500 mt-0.5">
-                  Running and pending counts per provider bucket
-                </p>
-              </div>
-            </div>
-            {queueAnalytics ? (
-              <ProviderBucketSummary analytics={queueAnalytics} />
-            ) : (
-              <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
-            )}
-          </Card>
-
-          {/* Recent Runs */}
-          <Card className="p-6">
-            <div className="flex items-center justify-between mb-4">
-              <div>
-                <h3 className="text-lg font-semibold text-slate-200">Recent Runs</h3>
-                <p className="text-xs text-slate-500 mt-0.5">
-                  Last 24 hours of job executions
-                </p>
-              </div>
-              {queueAnalytics?.averageWaitSeconds != null && (
-                <div className="text-xs text-slate-500">
-                  Avg wait: {Math.floor(queueAnalytics.averageWaitSeconds / 60)}m
-                </div>
-              )}
-            </div>
-            {queueAnalytics ? (
-              <RecentRunsChart analytics={queueAnalytics} />
-            ) : (
-              <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
-            )}
-          </Card>
-        </div>
+        <QueueTab
+          queueStatus={queueStatus}
+          queueAnalytics={queueAnalytics}
+          queueStatusError={queueStatusError}
+          queueAnalyticsError={queueAnalyticsError}
+        />
       ),
     },
-  ];
+  ], [
+    agents,
+    statusColor,
+    statusText,
+    isPaused,
+    scheduleInfo,
+    config,
+    allProjectConfigs,
+    queueStatus,
+    queueAnalytics,
+    queueStatusError,
+    queueAnalyticsError,
+    toggling,
+    saving,
+    editState,
+    showAddBucket,
+    newBucketKey,
+    newBucketConcurrency,
+    activeTemplate,
+  ]);
 
   return (
     <div className="space-y-6 max-w-6xl mx-auto">

--- a/web/pages/Scheduling.tsx
+++ b/web/pages/Scheduling.tsx
@@ -22,6 +22,9 @@ import Select from '../components/ui/Select';
 import Switch from '../components/ui/Switch';
 import Tabs from '../components/ui/Tabs';
 import ScheduleTimeline from '../components/scheduling/ScheduleTimeline.js';
+import ProviderLanesChart from '../components/scheduling/ProviderLanesChart.js';
+import ProviderBucketSummary from '../components/scheduling/ProviderBucketSummary.js';
+import RecentRunsChart from '../components/scheduling/RecentRunsChart.js';
 import { useStore } from '../store/useStore';
 import type { INightWatchConfig, IQueueAnalytics, IQueueStatus, QueueMode } from '../api';
 import {
@@ -910,6 +913,109 @@ const Scheduling: React.FC = () => {
               Save Queue Settings
             </Button>
           </div>
+        </div>
+      ),
+    },
+    {
+      id: 'queue',
+      label: 'Queue',
+      content: (
+        <div className="space-y-6">
+          {/* Queue Overview Card */}
+          <Card className="p-6">
+            <h3 className="text-lg font-semibold text-slate-200 mb-4">Queue Overview</h3>
+            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Running</div>
+                <div className="text-2xl font-bold text-green-400">
+                  {queueStatus?.running ? 1 : 0}
+                </div>
+                {queueStatus?.running && (
+                  <div className="text-xs text-slate-400 mt-1 truncate" title={queueStatus.running.projectName}>
+                    {queueStatus.running.jobType} · {queueStatus.running.projectName}
+                  </div>
+                )}
+              </div>
+              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Pending</div>
+                <div className="text-2xl font-bold text-blue-400">
+                  {queueStatus?.pending.total ?? 0}
+                </div>
+              </div>
+              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Avg Wait</div>
+                <div className="text-2xl font-bold text-slate-200">
+                  {queueStatus?.averageWaitSeconds != null
+                    ? `${Math.floor(queueStatus.averageWaitSeconds / 60)}m`
+                    : '—'}
+                </div>
+              </div>
+              <div className="bg-slate-950/40 rounded-lg p-4 border border-slate-800">
+                <div className="text-xs uppercase tracking-wide text-slate-500 mb-1">Oldest Pending</div>
+                <div className="text-2xl font-bold text-slate-200">
+                  {queueStatus?.oldestPendingAge != null
+                    ? `${Math.floor(queueStatus.oldestPendingAge / 60)}m`
+                    : '—'}
+                </div>
+              </div>
+            </div>
+          </Card>
+
+          {/* Provider Lanes */}
+          <Card className="p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-200">Provider Lanes</h3>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  Running and pending jobs grouped by provider bucket
+                </p>
+              </div>
+            </div>
+            {queueStatus ? (
+              <ProviderLanesChart status={queueStatus} />
+            ) : (
+              <div className="text-sm text-slate-500 py-2">Loading queue status...</div>
+            )}
+          </Card>
+
+          {/* Provider Bucket Summary */}
+          <Card className="p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-200">Provider Buckets</h3>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  Running and pending counts per provider bucket
+                </p>
+              </div>
+            </div>
+            {queueAnalytics ? (
+              <ProviderBucketSummary analytics={queueAnalytics} />
+            ) : (
+              <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
+            )}
+          </Card>
+
+          {/* Recent Runs */}
+          <Card className="p-6">
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-200">Recent Runs</h3>
+                <p className="text-xs text-slate-500 mt-0.5">
+                  Last 24 hours of job executions
+                </p>
+              </div>
+              {queueAnalytics?.averageWaitSeconds != null && (
+                <div className="text-xs text-slate-500">
+                  Avg wait: {Math.floor(queueAnalytics.averageWaitSeconds / 60)}m
+                </div>
+              )}
+            </div>
+            {queueAnalytics ? (
+              <RecentRunsChart analytics={queueAnalytics} />
+            ) : (
+              <div className="text-sm text-slate-500 py-2">Loading analytics...</div>
+            )}
+          </Card>
         </div>
       ),
     },

--- a/web/pages/__tests__/Scheduling.test.tsx
+++ b/web/pages/__tests__/Scheduling.test.tsx
@@ -303,19 +303,32 @@ describe('Scheduling page', () => {
       running: {
         id: 1,
         jobType: 'executor',
+        projectPath: '/path/to/test-project',
         projectName: 'test-project',
         providerKey: 'claude',
         status: 'running',
-        createdAt: new Date().toISOString(),
+        enqueuedAt: Date.now() / 1000,
+        dispatchedAt: null,
         priority: 50,
       },
       pending: { total: 3, byType: { executor: 2, reviewer: 1 }, byProviderBucket: {} },
     }));
     apiMocks.fetchQueueAnalytics.mockResolvedValue(makeQueueAnalytics({
       recentRuns: [
-        { id: 1, jobType: 'executor', projectName: 'test-project', status: 'completed', createdAt: new Date().toISOString(), completedAt: new Date().toISOString() },
+        {
+          id: 1,
+          jobType: 'executor',
+          projectPath: '/path/to/test-project',
+          providerKey: 'claude',
+          status: 'completed',
+          startedAt: Date.now() / 1000,
+          finishedAt: Date.now() / 1000,
+          waitSeconds: 0,
+          durationSeconds: 100,
+          throttledCount: 0,
+        },
       ],
-      byProviderBucket: { claude: { running: 1, pending: 2, completed: 5 } },
+      byProviderBucket: { claude: { running: 1, pending: 2 } },
     }));
 
     renderScheduling();

--- a/web/pages/__tests__/Scheduling.test.tsx
+++ b/web/pages/__tests__/Scheduling.test.tsx
@@ -297,4 +297,49 @@ describe('Scheduling page', () => {
     expect(screen.getByRole('button', { name: 'Open Jobs' })).toBeInTheDocument();
     expect(screen.queryByText('PRD Execution Schedule')).not.toBeInTheDocument();
   });
+
+  it('renders Queue tab with queue status and analytics', async () => {
+    apiMocks.fetchQueueStatus.mockResolvedValue(makeQueueStatus({
+      running: {
+        id: 1,
+        jobType: 'executor',
+        projectName: 'test-project',
+        providerKey: 'claude',
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        priority: 50,
+      },
+      pending: { total: 3, byType: { executor: 2, reviewer: 1 }, byProviderBucket: {} },
+    }));
+    apiMocks.fetchQueueAnalytics.mockResolvedValue(makeQueueAnalytics({
+      recentRuns: [
+        { id: 1, jobType: 'executor', projectName: 'test-project', status: 'completed', createdAt: new Date().toISOString(), completedAt: new Date().toISOString() },
+      ],
+      byProviderBucket: { claude: { running: 1, pending: 2, completed: 5 } },
+    }));
+
+    renderScheduling();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Queue' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Queue Overview')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Provider Lanes')).toBeInTheDocument();
+    expect(screen.getByText('Provider Buckets')).toBeInTheDocument();
+    expect(screen.getByText('Recent Runs')).toBeInTheDocument();
+  });
+
+  it('shows error state when queue status fails to load', async () => {
+    apiMocks.fetchQueueStatus.mockRejectedValue(new Error('Network error'));
+
+    renderScheduling();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Queue' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load queue status')).toBeInTheDocument();
+    });
+  });
 });

--- a/web/pages/__tests__/Scheduling.test.tsx
+++ b/web/pages/__tests__/Scheduling.test.tsx
@@ -312,6 +312,19 @@ describe('Scheduling page', () => {
         priority: 50,
       },
       pending: { total: 3, byType: { executor: 2, reviewer: 1 }, byProviderBucket: {} },
+      items: [
+        {
+          id: 2,
+          jobType: 'executor',
+          projectPath: '/path/to/test-project',
+          projectName: 'test-project',
+          providerKey: 'claude',
+          status: 'pending',
+          enqueuedAt: Date.now() / 1000,
+          dispatchedAt: null,
+          priority: 50,
+        },
+      ],
     }));
     apiMocks.fetchQueueAnalytics.mockResolvedValue(makeQueueAnalytics({
       recentRuns: [
@@ -342,17 +355,31 @@ describe('Scheduling page', () => {
     expect(screen.getByText('Provider Lanes')).toBeInTheDocument();
     expect(screen.getByText('Provider Buckets')).toBeInTheDocument();
     expect(screen.getByText('Recent Runs')).toBeInTheDocument();
+
+    // Verify sub-components render actual data
+    expect(screen.getByTestId('provider-lanes-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-lane-label-claude')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-bucket-summary')).toBeInTheDocument();
+    expect(screen.getByTestId('provider-bucket-claude')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-runs-chart')).toBeInTheDocument();
+    expect(screen.getByTestId('run-row-1')).toBeInTheDocument();
   });
 
   it('shows error state when queue status fails to load', async () => {
     apiMocks.fetchQueueStatus.mockRejectedValue(new Error('Network error'));
+    apiMocks.fetchQueueAnalytics.mockRejectedValue(new Error('Network error'));
 
     renderScheduling();
 
     fireEvent.click(screen.getByRole('button', { name: 'Queue' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Failed to load queue status')).toBeInTheDocument();
+      const statusErrors = screen.getAllByText('Failed to load queue status');
+      expect(statusErrors.length).toBeGreaterThanOrEqual(1);
     });
+
+    // Analytics errors also shown in respective cards
+    const analyticsErrors = screen.getAllByText('Failed to load analytics');
+    expect(analyticsErrors.length).toBeGreaterThanOrEqual(1);
   });
 });


### PR DESCRIPTION
## Summary

This PR completes the Provider-Aware Queue implementation (Phase 4 of the [Provider-Aware Weighted Scheduling PRD](docs/prds/provider-aware-weighted-scheduling.md)).

### Changes

- **Scheduling Page Queue Tab**: Added a new 'Queue' tab to the Scheduling page that visualizes:
  - **Queue Overview Card**: Shows running count, pending count, average wait time, and oldest pending age
  - **Provider Lanes Chart**: Visualizes running and pending jobs grouped by provider bucket
  - **Provider Bucket Summary**: Shows running/pending counts per provider bucket
  - **Recent Runs Chart**: Displays last 24 hours of job executions with status, duration, and wait time

### Implementation Status

The Provider-Aware Queue PRD phases 1-3 were already implemented:
- **Phase 1 (Queue Dispatch Correctness)**: ✅ Jobs rebuild env from queued project config
- **Phase 2 (Provider-Aware Scheduler)**: ✅ Provider bucket resolution and capacity checks
- **Phase 3 (Operational Telemetry)**: ✅ Job runs table and analytics APIs

This PR adds the Phase 4 UI components to visualize the queue state.

### Test plan

- [x] `yarn verify` passes
- [x] All existing tests pass
- [ ] Manual: Open Scheduling page, verify Queue tab shows correct data

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>