### PR TITLE
fix: preserve PR URL in opened notifications

### DIFF
--- a/packages/cli/src/__tests__/scripts/core-flow-smoke.test.ts
+++ b/packages/cli/src/__tests__/scripts/core-flow-smoke.test.ts
@@ -775,7 +775,8 @@ describe('core flow smoke tests (bash scripts)', () => {
         '  done\n' +
         '  if [[ -f "$NW_SMOKE_CREATED_FLAG" ]]; then\n' +
         '    if [[ "$jq_query" == *".url"* ]]; then\n' +
-        "      echo 'https://example.test/pull/123'\n" +
+        '      # Simulate a transient gh --jq lookup miss; final result should fall back to cached PR metadata.\n' +
+        '      exit 0\n' +
         '    elif [[ -n "$jq_query" ]]; then\n' +
         '      echo "$NW_SMOKE_BRANCH"\n' +
         '    else\n' +
@@ -815,6 +816,7 @@ describe('core flow smoke tests (bash scripts)', () => {
     expect(result.status).toBe(0);
     expect(result.stdout).toContain('NIGHT_WATCH_RESULT:success_open_pr');
     expect(result.stdout).toContain('pr_url=https://example.test/pull/123');
+    expect(result.stdout).toContain('pr_number=123');
     expect(fs.existsSync(createdFlag)).toBe(true);
   });
 

--- a/scripts/night-watch-cron.sh
+++ b/scripts/night-watch-cron.sh
@@ -1255,6 +1255,7 @@ if [ ${EXIT_CODE} -eq 0 ]; then
       # Board mode: comment with PR URL, then close issue and move to Done
       PR_URL=$(gh pr list --state open --json headRefName,url \
         --jq ".[] | select(.headRefName == \"${BRANCH_NAME}\") | .url" 2>/dev/null || true)
+      PR_URL=${PR_URL:-${EXECUTOR_PR_URL}}
       if [ -n "${PR_URL}" ]; then
         "${NW_CLI}" board comment "${ISSUE_NUMBER}" --body "PR opened: ${PR_URL} (via ${EFFECTIVE_PROVIDER_LABEL})" 2>>"${LOG_FILE}" || true
         gh pr comment "${PR_URL}" --body "> 🤖 Implemented by ${EFFECTIVE_PROVIDER_LABEL}" 2>>"${LOG_FILE}" || true
@@ -1262,16 +1263,17 @@ if [ ${EXIT_CODE} -eq 0 ]; then
       "${NW_CLI}" board close-issue "${ISSUE_NUMBER}" 2>>"${LOG_FILE}" || \
         "${NW_CLI}" board move-issue "${ISSUE_NUMBER}" --column "Done" 2>>"${LOG_FILE}" || true
       log "SUCCESS: PR opened and ready for review — ${PR_URL}"
-      emit_result "success_open_pr" "prd=${ELIGIBLE_PRD}|branch=${BRANCH_NAME}${PR_URL:+|pr_url=${PR_URL}}"
+      emit_result "success_open_pr" "prd=${ELIGIBLE_PRD}|branch=${BRANCH_NAME}${PR_URL:+|pr_url=${PR_URL}}${EXECUTOR_PR_NUMBER:+|pr_number=${EXECUTOR_PR_NUMBER}}"
     elif finalize_prd_done "implemented, PR opened on ${BRANCH_NAME}"; then
       # Non-board mode: post attribution comment to the PR
       NON_BOARD_PR_URL=$(gh pr list --state open --json headRefName,url \
         --jq ".[] | select(.headRefName == \"${BRANCH_NAME}\") | .url" 2>/dev/null || true)
+      NON_BOARD_PR_URL=${NON_BOARD_PR_URL:-${EXECUTOR_PR_URL}}
       if [ -n "${NON_BOARD_PR_URL}" ]; then
         gh pr comment "${NON_BOARD_PR_URL}" --body "> 🤖 Implemented by ${EFFECTIVE_PROVIDER_LABEL}" 2>>"${LOG_FILE}" || true
       fi
       log "SUCCESS: PR opened and ready for review — ${NON_BOARD_PR_URL}"
-      emit_result "success_open_pr" "prd=${ELIGIBLE_PRD}|branch=${BRANCH_NAME}${NON_BOARD_PR_URL:+|pr_url=${NON_BOARD_PR_URL}}"
+      emit_result "success_open_pr" "prd=${ELIGIBLE_PRD}|branch=${BRANCH_NAME}${NON_BOARD_PR_URL:+|pr_url=${NON_BOARD_PR_URL}}${EXECUTOR_PR_NUMBER:+|pr_number=${EXECUTOR_PR_NUMBER}}"
     else
       night_watch_history record "${PROJECT_DIR}" "${ELIGIBLE_PRD}" failure --exit-code 1 2>/dev/null || true
       emit_result "failure_finalize" "prd=${ELIGIBLE_PRD}|branch=${BRANCH_NAME}|reason=finalize_failed|detail=Failed_to_finalize_open_prd"


### PR DESCRIPTION
## Summary
- fall back to cached executor PR metadata when the final gh --jq URL lookup is empty
- include pr_number in success_open_pr markers so CLI enrichment has a stable selector
- add smoke coverage for transient gh URL lookup misses

## Tests
- yarn vitest run packages/cli/src/__tests__/commands/run.test.ts packages/core/src/__tests__/utils/notify.test.ts packages/cli/src/__tests__/scripts/core-flow-smoke.test.ts -t "executor should defer draft PR creation|notification integration|formatTelegramPayload" --run
- yarn verify